### PR TITLE
Minor changes to support gcc 4.7

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -29,6 +29,7 @@
 #ifndef CEREAL_CEREAL_HPP_
 #define CEREAL_CEREAL_HPP_
 
+#include <stdexcept>
 #include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
@@ -46,7 +47,8 @@ namespace cereal
   /*! @ingroup Utility */
   struct Exception : public std::runtime_error
   {
-    using std::runtime_error::runtime_error;
+    Exception( const std::string& what ) : std::runtime_error(what) {}
+    Exception( const char* what ) : std::runtime_error(what) {}
   };
 
   // ######################################################################

--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -207,7 +207,7 @@ namespace cereal
         typename OutputBindingMap<Archive>::Serializers serializers;
 
         serializers.shared_ptr =
-          [](void * arptr, void const * dptr)
+          [&](void * arptr, void const * dptr)
           {
             Archive & ar = *static_cast<Archive*>(arptr);
 
@@ -219,7 +219,7 @@ namespace cereal
           };
 
         serializers.unique_ptr =
-          [](void * arptr, void const * dptr)
+          [&](void * arptr, void const * dptr)
           {
             Archive & ar = *static_cast<Archive*>(arptr);
 


### PR DESCRIPTION
This passes unit tests on my machine, but is only tested with gcc 4.7.3.  FYI, Ubuntu 13.04 comes with gcc 4.7.3.

By inspection, I think the changes to `cereal.hpp` will work everywhere (and it only loses one little C++11 nicety), but I'm don't totally understand the lambda capture changes in `polymorphic_impl.hpp`.

```
gcc 4.7 has significant C++11 support, but is missing some features.
See http://gcc.gnu.org/gcc-4.7/cxx0x_status.html

* #include <stdexcept> was needed to find std::runtime_error

* gcc 4.7 does not support "Inheriting constructors".  This was fixed by using
  the traditional method of explicitly declaring the constructors.

* Some lambda expressions needed extra love.  More color here:
  http://stackoverflow.com/questions/4940259/c11-lambdas-require-capturing-this-to-call-static-member-function

These changes are minor so I did not use gcc version detection via preprocessor.
```
