### PR TITLE
Fix clang++ compiler error

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -358,7 +358,7 @@ namespace cereal
       };
 
       //! Loads the size for a SizeTag
-      void loadSize(size_t & size)
+      void loadSize(size_type & size)
       {
         size = (itsValueStack.rbegin() + 1)->value().Size();
       }


### PR DESCRIPTION
When compiling with a recent clang++, I got the following error:

clang++ unittests.cpp -o unittests -lboost_unit_test_framework -std=c++11 -I./include -Wall -Werror -g
In file included from unittests.cpp:50:
./include/cereal/archives/json.hpp:574:18: error: non-const lvalue reference to type 'size_t'
      (aka 'unsigned long') cannot bind to a value of unrelated type 'unsigned long long'
    ar.loadSize( st.size );
[...]

The attached patch fixes the error. I assume this is just a small left-over stray size_t related to commit bfe2289?
