### PR TITLE
Removed extra unneeded semi-colons

### DIFF
--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -77,7 +77,7 @@ namespace cereal
     char & serialize(...);
     template<typename T, typename A>
       bool constexpr has_non_member_serialize()
-      { return std::is_void<decltype(serialize(std::declval<A&>(), std::declval<T&>()))>::value; };
+      { return std::is_void<decltype(serialize(std::declval<A&>(), std::declval<T&>()))>::value; }
 
     // ######################################################################
     // Member Load
@@ -96,7 +96,7 @@ namespace cereal
     char & load(...);
     template<typename T, typename A>
       bool constexpr has_non_member_load()
-      { return std::is_void<decltype(load(std::declval<A&>(), std::declval<T&>()))>::value; };
+      { return std::is_void<decltype(load(std::declval<A&>(), std::declval<T&>()))>::value; }
 
     // ######################################################################
     // Member Save


### PR DESCRIPTION
There are extra semi-colons following the `constexpr` functions `has_non_member_serialize()` and `has_non_member_load()`. This is flagged with `-pedantic` on `gcc`.
