### PR TITLE
Added a 'getNodeName' API to JSON/XML InputArchives

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -558,6 +558,12 @@ namespace cereal
         ++itsIteratorStack.back();
       }
 
+      //! Retrieves the current node name
+      //! will return @c nullptr if the node does not have a name
+      const char * getNodeName() const {
+        return itsIteratorStack.back().name();
+      }
+
       //! Sets the name for the next node created with startNode
       void setNextName( const char * name )
       {

--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -461,6 +461,12 @@ namespace cereal
         itsNodes.top().name = nullptr;
       }
 
+      //! Retrieves the current node name
+      //! will return @c nullptr if the node does not have a name
+      const char * getNodeName() const {
+        return itsNodes.top().node->name();
+      }
+
       //! Sets the name for the next node created with startNode
       void setNextName( const char * name )
       {


### PR DESCRIPTION
If you are doing some pretty custom serialization/deserialization it can really help being able to know the current node key/tag.

I couldn't really figure out where to put this into the unit tests - any hints? Would you want tests for this?
