### PR TITLE
add CMake-option 'SKIP_PORTABILITY_TEST'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required (VERSION 2.6.2)
 project (cereal)
 
+option(SKIP_PORTABILITY_TEST "Skip portability tests" OFF)
+
 set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Werror -g -Wextra -Wshadow -pedantic ${CMAKE_CXX_FLAGS}")
 
 include_directories(./include)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -4,7 +4,7 @@ file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 set(SPECIAL_TESTS "portability_test.cpp")
 
 # Build the portability test only if we are on a 64-bit machine (void* is 8 bytes)
-if(${CMAKE_SIZEOF_VOID_P} EQUAL 8) 
+if((${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
   add_executable(portability_test32 portability_test.cpp)
   set_target_properties(portability_test32 PROPERTIES COMPILE_FLAGS "-m32")
   set_target_properties(portability_test32 PROPERTIES LINK_FLAGS "-m32")


### PR DESCRIPTION
Hello!

I want to package cereal for Fedora and RHEL / CentOS7 (EPEL).  Unfortunately I cannot run cross-compilation in the Fedora-builder's buildroot.  Therefore I added this CMake-option to disable the portability-tests.
