### PR TITLE
allow for cereal to be applied to template classes with multiple arguments

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -56,17 +56,17 @@
     have been registered with CEREAL_REGISTER_ARCHIVE.  This must be called
     after all archives are registered (usually after the archives themselves
     have been included). */
-#define CEREAL_BIND_TO_ARCHIVES(T)                           \
-    namespace cereal {                                       \
-    namespace detail {                                       \
-    template<>                                               \
-    struct init_binding<T> {                                 \
-        static bind_to_archives<T> const & b;                \
-    };                                                       \
-    bind_to_archives<T> const & init_binding<T>::b =         \
-        ::cereal::detail::StaticObject<                      \
-            bind_to_archives<T>                              \
-        >::getInstance().bind();                             \
+#define CEREAL_BIND_TO_ARCHIVES(...)                                     \
+    namespace cereal {                                                   \
+    namespace detail {                                                   \
+    template<>                                                           \
+    struct init_binding<__VA_ARGS__> {                                   \
+        static bind_to_archives<__VA_ARGS__> const & b;                  \
+    };                                                                   \
+    bind_to_archives<__VA_ARGS__> const & init_binding<__VA_ARGS__>::b = \
+        ::cereal::detail::StaticObject<                                  \
+            bind_to_archives<__VA_ARGS__>                                \
+        >::getInstance().bind();                                         \
     }} // end namespaces
 
 namespace cereal

--- a/include/cereal/types/polymorphic.hpp
+++ b/include/cereal/types/polymorphic.hpp
@@ -59,16 +59,16 @@
 
     Polymorphic support in cereal requires RTTI to be
     enabled */
-#define CEREAL_REGISTER_TYPE(T)                         \
-  namespace cereal {                                    \
-  namespace detail {                                    \
-  template <>                                           \
-  struct binding_name<T>                                \
-  {                                                     \
-    STATIC_CONSTEXPR char const * name() { return #T; } \
-  };                                                    \
-  } } /* end namespaces */                              \
-  CEREAL_BIND_TO_ARCHIVES(T)
+#define CEREAL_REGISTER_TYPE(...)                                 \
+  namespace cereal {                                              \
+  namespace detail {                                              \
+  template <>                                                     \
+  struct binding_name<__VA_ARGS__>                                \
+  {                                                               \
+    STATIC_CONSTEXPR char const * name() { return #__VA_ARGS__; } \
+  };                                                              \
+  } } /* end namespaces */                                        \
+  CEREAL_BIND_TO_ARCHIVES(__VA_ARGS__)
 
 //! Registers a polymorphic type with cereal, giving it a
 //! user defined name


### PR DESCRIPTION
This uses __VA_ARGS__ instead of T in the macro argument list to allow for template classes with multiple arguments.  I _think_ it should be strictly more functionality and not break anything that worked before (but I might be wrong).  Also, I didn't touch CEREAL_REGISTER_TYPE_WITH_NAME because I would have had to switch the argument order in the macro to use __VA_ARGS__, which would definitely break things.