### PR TITLE
Implement Tuple Name Differences in XML/JSON

### DIFF
--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -45,7 +45,9 @@ namespace cereal
       template <class Archive, class ... Types> inline
       static void apply( Archive & ar, std::tuple<Types...> & tuple )
       {
-        ar( _CEREAL_NVP("tuple_element", std::get<Height - 1>( tuple )) );
+        
+        ar( _CEREAL_NVP(("tuple_element" + std::to_string(Height -1)).c_str(),
+          std::get<Height - 1>( tuple )) );
         serialize<Height - 1>::template apply( ar, tuple );
       }
     };


### PR DESCRIPTION
User rggjan requested that tuples provide a different name for each
element in this issue: https://github.com/USCiLab/cereal/issues/140.

This fix modifies tuple.hpp to generate tuple names in the order which
they are are placed in the tuple.  Note that this will appear to be a
countdown (tuple_element2, tuple_element1, tuple_element0) since tuples
are generated in reverse order.

Signed-off-by: Erich Keane <erich.keane@verizon.net>