### PR TITLE
Implemented MinimalJSONOutputArchive

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -259,7 +259,7 @@ namespace cereal
       private:
         template<class WT = WriterType>
         typename std::enable_if<std::is_same<MinimalWriter, WT>::value>::type
-        init(Options const & options)
+        init(Options const &)
         {
           itsNameCounter.push(0);
           itsNodeStack.push(NodeType::StartObject);

--- a/unittests/array.cpp
+++ b/unittests/array.cpp
@@ -111,3 +111,7 @@ BOOST_AUTO_TEST_CASE( json_array )
   test_array<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_array )
+{
+  test_array<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/basic_string.cpp
+++ b/unittests/basic_string.cpp
@@ -125,3 +125,7 @@ BOOST_AUTO_TEST_CASE( json_string_basic )
   test_string_basic<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_string_basic )
+{
+  test_string_basic<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/bitset.cpp
+++ b/unittests/bitset.cpp
@@ -91,4 +91,7 @@ BOOST_AUTO_TEST_CASE( json_bitset )
   test_bitset<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
-
+BOOST_AUTO_TEST_CASE( minimal_json_bitset )
+{
+  test_bitset<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/chrono.cpp
+++ b/unittests/chrono.cpp
@@ -120,4 +120,7 @@ BOOST_AUTO_TEST_CASE( json_chrono )
   test_chrono<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
-
+BOOST_AUTO_TEST_CASE( minimal_json_chrono )
+{
+  test_chrono<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/complex.cpp
+++ b/unittests/complex.cpp
@@ -93,4 +93,7 @@ BOOST_AUTO_TEST_CASE( json_complex )
   test_complex<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
-
+BOOST_AUTO_TEST_CASE( minimal_json_complex )
+{
+  test_complex<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/deque.cpp
+++ b/unittests/deque.cpp
@@ -116,3 +116,8 @@ BOOST_AUTO_TEST_CASE( json_dequeue )
 {
   test_deque<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_dequeue )
+{
+  test_deque<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/forward_list.cpp
+++ b/unittests/forward_list.cpp
@@ -110,3 +110,8 @@ BOOST_AUTO_TEST_CASE( json_forward_list )
 {
   test_forward_list<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_forward_list )
+{
+  test_forward_list<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/list.cpp
+++ b/unittests/list.cpp
@@ -111,3 +111,7 @@ BOOST_AUTO_TEST_CASE( json_list )
   test_list<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_list )
+{
+  test_list<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/load_construct.cpp
+++ b/unittests/load_construct.cpp
@@ -193,3 +193,7 @@ BOOST_AUTO_TEST_CASE( json_memory_load_construct )
   test_memory_load_construct<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_memory_load_construct )
+{
+  test_memory_load_construct<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/map.cpp
+++ b/unittests/map.cpp
@@ -204,3 +204,8 @@ BOOST_AUTO_TEST_CASE( json_map_memory )
 {
   test_map_memory<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_map_memory )
+{
+  test_map_memory<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/memory.cpp
+++ b/unittests/memory.cpp
@@ -99,3 +99,7 @@ BOOST_AUTO_TEST_CASE( json_memory )
   test_memory<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_memory )
+{
+  test_memory<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/memory_cycles.cpp
+++ b/unittests/memory_cycles.cpp
@@ -159,3 +159,7 @@ BOOST_AUTO_TEST_CASE( json_memory_cycles )
   test_memory_cycles<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_memory_cycles )
+{
+  test_memory_cycles<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/multimap.cpp
+++ b/unittests/multimap.cpp
@@ -145,3 +145,7 @@ BOOST_AUTO_TEST_CASE( json_multimap )
   test_multimap<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_multimap )
+{
+  test_multimap<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/multiset.cpp
+++ b/unittests/multiset.cpp
@@ -150,4 +150,8 @@ BOOST_AUTO_TEST_CASE( json_multiset )
   test_multiset<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_multiset )
+{
+  test_multiset<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}
 

--- a/unittests/pair.cpp
+++ b/unittests/pair.cpp
@@ -102,8 +102,13 @@ BOOST_AUTO_TEST_CASE( xml_pair )
 {
   test_pair<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
 }
+
 BOOST_AUTO_TEST_CASE( json_pair )
 {
   test_pair<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_pair )
+{
+  test_pair<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/pod.cpp
+++ b/unittests/pod.cpp
@@ -152,3 +152,8 @@ BOOST_AUTO_TEST_CASE( json_pod )
 {
   test_pod<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_pod )
+{
+  test_pod<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/polymorphic.cpp
+++ b/unittests/polymorphic.cpp
@@ -210,3 +210,7 @@ BOOST_AUTO_TEST_CASE( json_polymorphic )
   test_polymorphic<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_polymorphic )
+{
+  test_polymorphic<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/priority_queue.cpp
+++ b/unittests/priority_queue.cpp
@@ -123,3 +123,7 @@ BOOST_AUTO_TEST_CASE( json_priority_queue )
   test_priority_queue<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_priority_queue )
+{
+  test_priority_queue<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/queue.cpp
+++ b/unittests/queue.cpp
@@ -123,3 +123,7 @@ BOOST_AUTO_TEST_CASE( json_queue )
   test_queue<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_queue )
+{
+  test_queue<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/set.cpp
+++ b/unittests/set.cpp
@@ -111,3 +111,7 @@ BOOST_AUTO_TEST_CASE( json_set )
   test_set<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_set )
+{
+  test_set<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/stack.cpp
+++ b/unittests/stack.cpp
@@ -123,3 +123,7 @@ BOOST_AUTO_TEST_CASE( json_stack )
   test_stack<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_stack )
+{
+  test_stack<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/structs.cpp
+++ b/unittests/structs.cpp
@@ -83,3 +83,8 @@ BOOST_AUTO_TEST_CASE( json_structs )
 {
   test_structs<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_structs )
+{
+  test_structs<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/structs_minimal.cpp
+++ b/unittests/structs_minimal.cpp
@@ -186,3 +186,8 @@ BOOST_AUTO_TEST_CASE( json_structs_minimal )
 {
   test_structs_minimal<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_structs_minimal )
+{
+  test_structs_minimal<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/structs_specialized.cpp
+++ b/unittests/structs_specialized.cpp
@@ -434,3 +434,7 @@ BOOST_AUTO_TEST_CASE( json_structs_specialized )
   test_structs_specialized<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_structs_specialized )
+{
+  test_structs_specialized<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/tuple.cpp
+++ b/unittests/tuple.cpp
@@ -111,3 +111,7 @@ BOOST_AUTO_TEST_CASE( json_tuple )
   test_tuple<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_tuple )
+{
+  test_tuple<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/unordered_loads.cpp
+++ b/unittests/unordered_loads.cpp
@@ -151,3 +151,7 @@ BOOST_AUTO_TEST_CASE( json_unordered_loads )
   test_unordered_loads<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_unordered_loads )
+{
+  test_unordered_loads<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/unordered_map.cpp
+++ b/unittests/unordered_map.cpp
@@ -140,3 +140,7 @@ BOOST_AUTO_TEST_CASE( json_unordered_map )
   test_unordered_map<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_unordered_map )
+{
+  test_unordered_map<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/unordered_multimap.cpp
+++ b/unittests/unordered_multimap.cpp
@@ -170,3 +170,8 @@ BOOST_AUTO_TEST_CASE( json_unordered_multimap )
 {
   test_unordered_multimap<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
+
+BOOST_AUTO_TEST_CASE( minimal_json_unordered_multimap )
+{
+  test_unordered_multimap<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/unordered_multiset.cpp
+++ b/unittests/unordered_multiset.cpp
@@ -150,3 +150,7 @@ BOOST_AUTO_TEST_CASE( json_unordered_multiset )
   test_unordered_multiset<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_unordered_multiset )
+{
+  test_unordered_multiset<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}

--- a/unittests/unordered_set.cpp
+++ b/unittests/unordered_set.cpp
@@ -130,4 +130,8 @@ BOOST_AUTO_TEST_CASE( json_unordered_set )
   test_unordered_set<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_unordered_set )
+{
+  test_unordered_set<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}
 

--- a/unittests/vector.cpp
+++ b/unittests/vector.cpp
@@ -126,4 +126,8 @@ BOOST_AUTO_TEST_CASE( json_vector )
   test_vector<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_vector )
+{
+  test_vector<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}
 

--- a/unittests/versioning.cpp
+++ b/unittests/versioning.cpp
@@ -189,3 +189,7 @@ BOOST_AUTO_TEST_CASE( json_versioning )
   test_versioning<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+BOOST_AUTO_TEST_CASE( minimal_json_versioning )
+{
+  test_versioning<cereal::JSONInputArchive, cereal::MinimalJSONOutputArchive>();
+}


### PR DESCRIPTION
RapidJSON supports a non-whitespace version of the writer.
This commit changes the current JSONOutputArchive to exist inside
the details namespace (and be renamed as JSONOutputArchiveImpl)
and defines 2 usings for JSONOutputArchive and MinimalJSONOutputArchive.

JSONOutputArchive should support everything that the old one does,
Minimal has a slightly less featureful version of Options (since
indent and indent count aren't necessary) but prints without
unnecessary whitespace

Signed-off-by: Erich Keane erich.keane@verizon.net
