### PR TITLE
Fixed off-by-one memory allocation in xml

### DIFF
--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -196,7 +196,7 @@ namespace cereal
         const auto nameString = itsNodes.top().getValueName();
 
         // allocate strings for all of the data in the XML object
-        auto namePtr = itsXML.allocate_string( nameString.data(), nameString.size() );
+        auto namePtr = itsXML.allocate_string( nameString.data(), nameString.length() + 1 );
 
         // insert into the XML
         auto node = itsXML.allocate_node( rapidxml::node_element, namePtr, nullptr, nameString.size() );
@@ -227,7 +227,7 @@ namespace cereal
         itsOS << value << std::ends;
 
         // allocate strings for all of the data in the XML object
-        auto dataPtr = itsXML.allocate_string( itsOS.str().c_str() );
+        auto dataPtr = itsXML.allocate_string( itsOS.str().c_str(), itsOS.str().length() + 1 );
 
         // insert into the XML
         itsNodes.top().node->append_node( itsXML.allocate_node( rapidxml::node_data, nullptr, dataPtr ) );
@@ -256,7 +256,7 @@ namespace cereal
         const auto nameString = util::demangledName<T>();
 
         // allocate strings for all of the data in the XML object
-        auto namePtr = itsXML.allocate_string( nameString.data(), nameString.size() );
+        auto namePtr = itsXML.allocate_string( nameString.data(), nameString.length() + 1 );
 
         itsNodes.top().node->append_attribute( itsXML.allocate_attribute( "type", namePtr ) );
       }


### PR DESCRIPTION
This defect was discovered in issue #153, and resulted in reading
past memory.  This fix repairs the off-by-one situations.  Additionally,
in usages of this function where the size is known, it saves processing
by using the std::string's length property.

Signed-off-by: Erich Keane <erich.keane@verizon.net>