### PR TITLE
Json and Xml archive fixes

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -153,7 +153,8 @@ namespace cereal
       //! Destructor, flushes the JSON
       ~JSONOutputArchive()
       {
-        itsWriter.EndObject();
+        if (itsNodeStack.top() == NodeType::InObject)
+          itsWriter.EndObject();
       }
 
       //! Saves some binary data, encoded as a base64 string, with an optional name

--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -258,7 +258,7 @@ namespace cereal
         // allocate strings for all of the data in the XML object
         auto namePtr = itsXML.allocate_string( nameString.data(), nameString.size() );
 
-        itsNodes.top().node->append_attribute( itsXML.allocate_attribute( "type", namePtr ) );
+        itsNodes.top().node->append_attribute( itsXML.allocate_attribute( "type", namePtr, 0, nameString.size() ) );
       }
 
       //! Appends an attribute to the current top level node


### PR DESCRIPTION
There was a buffer over-read when enabling the output of the types in the xml outputarchive.
Creating a JSONOutputArchive without serializing anything results in a failed assertion when the destructor was called.