### PR TITLE
Fix for partial updates when variable names have common root

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -491,7 +491,8 @@ namespace cereal
             const auto len = std::strlen( searchName );
             size_t index = 0;
             for( auto it = itsMemberItBegin; it != itsMemberItEnd; ++it, ++index )
-              if( std::strncmp( searchName, it->name.GetString(), len ) == 0 )
+              if( std::strncmp( searchName, it->name.GetString(), len ) == 0 &&
+                  len == std::strlen( it->name.GetString() ) )
               {
                 itsIndex = index;
                 return;


### PR DESCRIPTION
In this case we have two or more variables with partially matched names (common root abc): abc and abcxyz.
If we use json archive and try to apply a partial update to variable abcxyz it will update both variables.
The proposed fix should take care of it.

Below is an example which demonstrates this behavior.


/*
footest.cpp

compile and run

footest  '{ "Foo": {"abcxyz":67} }'

*/

#include <cereal/archives/json.hpp>
#include <iostream>
#include <sstream>

// ignore exeptions
#define WRAP(n) try {ar(CEREAL_NVP(n));} catch(...){}

struct Foo
{
int abc = 11;
int abcxyz = 12;

friend class cereal::access;
template <class Archive>
void serialize( Archive & ar )
{
    WRAP(abc);
    WRAP(abcxyz);
}

};

int
main(int argc, char ** argv)
{
std::string s = "";
if (argc > 1)
{
s = argv[1];
std::cout << "s="<< s << std::endl;
}

Foo foo;
std::cout << std::endl << "===" << std::endl;
{
    cereal::JSONOutputArchive ar(std::cout);
    ar( cereal::make_nvp("Foo", foo) );
}
std::cout << std::endl;

if (s != "")
{
    std::cout << std::endl << "---" << std::endl;
    std::istringstream istr( s.c_str() ); 

    cereal::JSONInputArchive ar(istr);
    ar( cereal::make_nvp("Foo", foo) );             
    {
        cereal::JSONOutputArchive ar_out(std::cout);
        ar_out( cereal::make_nvp("Foo", foo) );
    }
}

}