### PR TITLE
Added support for std::valarray.

### DIFF
--- a/include/cereal/types/valarray.hpp
+++ b/include/cereal/types/valarray.hpp
@@ -1,0 +1,103 @@
+/*! \file valarray.hpp
+\brief Support for types found in \<valarray\>
+\ingroup STLSupport */
+
+/*
+Copyright (c) 2014, Randolph Voorhies, Shane Grant
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of cereal nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES OR SHANE GRANT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef CEREAL_TYPES_VALARRAY_HPP_
+#define CEREAL_TYPES_VALARRAY_HPP_
+
+#include <cereal/cereal.hpp>
+#include <valarray>
+
+namespace cereal
+{
+	/* Implementation note
+	Since valarray can only contain arithmetic types, pointer or other valarrays we need to define serialization for all the cases mentioned
+	Following implementation in valarray.hpp we get serialization for std::valarray arithmetic values directly and all other cases implemented as calls
+	for underlying serialization of every valarray element. */
+
+	//! Saving for std::valarray arithmetic types
+	//! using binary serialization, if supported
+	template <class Archive, class T> inline
+		typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
+		&& std::is_arithmetic<T>::value, void>::type
+		CEREAL_SAVE_FUNCTION_NAME(Archive & ar, std::valarray<T> const & valarray)
+	{
+			size_type valarraySize = static_cast<size_type>(valarray.size()); //get valarray size
+			ar(make_size_tag(valarraySize)); // save number of elements
+			if (valarraySize > 0) { // save data if it's not empty
+				ar(binary_data(&valarray[0], static_cast<size_t>(valarraySize) * sizeof(T))); // &valarray[0] applicable since std::valarray guaranteed to be stored contignously
+			}
+		}
+
+	//! Loading for std::valarray arithmetic types
+	//! using binary serialization, if supported
+	template <class Archive, class T> inline
+		typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
+		&& std::is_arithmetic<T>::value, void>::type
+		CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::valarray<T> & valarray)
+	{
+			size_type valarraySize;
+			ar(make_size_tag(valarraySize));
+
+			valarray.resize(static_cast<std::size_t>(valarraySize));
+			if (valarraySize > 0) { // load data if it's not empty
+				ar( binary_data(&valarray[0], static_cast<std::size_t>(valarraySize) * sizeof(T)) );
+			}
+		}
+
+	//! Saving for std::valarray all other types
+	template <class Archive, class T> inline
+		typename std::enable_if<!traits::is_output_serializable<BinaryData<T>, Archive>::value
+		|| !std::is_arithmetic<T>::value, void>::type
+		CEREAL_SAVE_FUNCTION_NAME(Archive & ar, std::valarray<T> const & valarray)
+	{
+			ar(make_size_tag(static_cast<size_type>(valarray.size()))); // number of elements
+			for (auto const & i : valarray)
+				ar(i);
+		}
+
+	//! Loading for std::valarray all other types
+	template <class Archive, class T> inline
+		typename std::enable_if<!traits::is_input_serializable<BinaryData<T>, Archive>::value
+		|| !std::is_arithmetic<T>::value, void>::type
+		CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::valarray<T> & valarray)
+	{
+			size_type valarraySize;
+			ar(make_size_tag(valarraySize));
+
+			valarray.resize(static_cast<size_t>(valarraySize));
+			if (valarraySize > 0) { // load data if it's not empty
+				for (auto & i : valarray)
+					ar(i);
+			}
+		}
+} // namespace cereal
+
+#endif // CEREAL_TYPES_VALARRAY_HPP_

--- a/unittests/common.hpp
+++ b/unittests/common.hpp
@@ -29,6 +29,7 @@
 
 #include <cereal/types/memory.hpp>
 #include <cereal/types/array.hpp>
+#include <cereal/types/valarray.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/deque.hpp>
 #include <cereal/types/forward_list.hpp>

--- a/unittests/valarray.cpp
+++ b/unittests/valarray.cpp
@@ -1,0 +1,120 @@
+/*
+Copyright (c) 2014, Randolph Voorhies, Shane Grant
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of cereal nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES AND SHANE GRANT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "common.hpp"
+#include <boost/test/unit_test.hpp>
+
+template <class IArchive, class OArchive>
+void test_valarray()
+{
+	std::random_device rd;
+	std::mt19937 gen(rd());
+
+	for (int ii = 0; ii<100; ++ii)
+	{
+		std::valarray<int> o_podvalarray(100);
+		for (auto & elem : o_podvalarray)
+			elem = random_value<int>(gen);
+
+		std::valarray<StructInternalSerialize> o_iservalarray(100);
+		for (auto & elem : o_iservalarray)
+			elem = StructInternalSerialize(random_value<int>(gen), random_value<int>(gen));
+
+		std::valarray<StructInternalSplit> o_isplvalarray(100);
+		for (auto & elem : o_isplvalarray)
+			elem = StructInternalSplit(random_value<int>(gen), random_value<int>(gen));
+
+		std::valarray<StructExternalSerialize> o_eservalarray(100);
+		for (auto & elem : o_eservalarray)
+			elem = StructExternalSerialize(random_value<int>(gen), random_value<int>(gen));
+
+		std::valarray<StructExternalSplit> o_esplvalarray(100);
+		for (auto & elem : o_esplvalarray)
+			elem = StructExternalSplit(random_value<int>(gen), random_value<int>(gen));
+
+		std::ostringstream os;
+		{
+			OArchive oar(os);
+
+			oar(o_podvalarray);
+			oar(o_iservalarray);
+			oar(o_isplvalarray);
+			oar(o_eservalarray);
+			oar(o_esplvalarray);
+		}
+
+		std::valarray<int> i_podvalarray;
+		std::valarray<StructInternalSerialize> i_iservalarray;
+		std::valarray<StructInternalSplit>     i_isplvalarray;
+		std::valarray<StructExternalSerialize> i_eservalarray;
+		std::valarray<StructExternalSplit>     i_esplvalarray;
+
+		std::istringstream is(os.str());
+		{
+			IArchive iar(is);
+
+			iar(i_podvalarray);
+			iar(i_iservalarray);
+			iar(i_isplvalarray);
+			iar(i_eservalarray);
+			iar(i_esplvalarray);
+		}
+
+		BOOST_CHECK_EQUAL(i_podvalarray.size(), o_podvalarray.size());
+		BOOST_CHECK_EQUAL(i_iservalarray.size(), o_iservalarray.size());
+		BOOST_CHECK_EQUAL(i_isplvalarray.size(), o_isplvalarray.size());
+		BOOST_CHECK_EQUAL(i_eservalarray.size(), o_eservalarray.size());
+		BOOST_CHECK_EQUAL(i_esplvalarray.size(), o_esplvalarray.size());
+
+		BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(i_podvalarray), std::end(i_podvalarray), std::begin(o_podvalarray), std::end(o_podvalarray));
+		BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(i_iservalarray), std::end(i_iservalarray), std::begin(o_iservalarray), std::end(o_iservalarray));
+		BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(i_isplvalarray), std::end(i_isplvalarray), std::begin(o_isplvalarray), std::end(o_isplvalarray));
+		BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(i_eservalarray), std::end(i_eservalarray), std::begin(o_eservalarray), std::end(o_eservalarray));
+		BOOST_CHECK_EQUAL_COLLECTIONS(std::begin(i_esplvalarray), std::end(i_esplvalarray), std::begin(o_esplvalarray), std::end(o_esplvalarray));
+	}
+}
+
+BOOST_AUTO_TEST_CASE(binary_valarray)
+{
+	test_valarray<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE(portable_binary_valarray)
+{
+	test_valarray<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE(xml_valarray)
+{
+	test_valarray<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE(json_valarray)
+{
+	test_valarray<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+

--- a/vs2013/unittests/unittests.vcxproj
+++ b/vs2013/unittests/unittests.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -52,6 +52,7 @@
     <ClCompile Include="..\..\unittests\unordered_set.cpp" />
     <ClCompile Include="..\..\unittests\user_data_adapters.cpp" />
     <ClCompile Include="..\..\unittests\vector.cpp" />
+    <ClCompile Include="..\..\unittests\valarray.cpp" />
     <ClCompile Include="..\..\unittests\versioning.cpp" />
     <ClCompile Include="main.cpp" />
   </ItemGroup>
@@ -103,7 +104,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>$(SolutionDir)\..\include;$(SolutionDir)\..\unittests;E:\Boost\include\boost-1_55;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\..\include;$(SolutionDir)\..\unittests;D:\Libs\boost_1_58_0;$(IncludePath)</IncludePath>
     <LibraryPath>E:\Boost\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -111,7 +112,7 @@
     <LibraryPath>E:\Boost\lib\x64;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IncludePath>$(SolutionDir)\..\include;$(SolutionDir)\..\unittests;E:\Boost\include\boost-1_55;$(IncludePath)</IncludePath>
+    <IncludePath>$(SolutionDir)\..\include;$(SolutionDir)\..\unittests;D:\Libs\boost_1_58_0;$(IncludePath)</IncludePath>
     <LibraryPath>E:\Boost\lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/vs2013/unittests/unittests.vcxproj.filters
+++ b/vs2013/unittests/unittests.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -109,6 +109,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\unittests\vector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+     <ClCompile Include="..\..\unittests\valarray.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\unittests\versioning.cpp">


### PR DESCRIPTION
Motivation
I'm using cereal++ as underlying serialization lib for high perfomance scientific computing, and std::valarray is the type specifically held in STL for this particular purpose. I found that std::valarray serialization wasn't supported yet, so i decided to contribute to this nice project with my implementation. Please be kind to review this pull request.

Here is what has beed done :
1) Implemented std::valarray serialization (based on vector.hpp) in file valarray.hpp
2) Implemented unit tests in file valarray.cpp (based on vector.cpp tests, except for bool case)
3) vs2013/unittests project configuration updated accordingly
4) unittests/common.hpp updated.
5) No documentation so far (not sure how to do it properly)