### PR TITLE
Fix shared_ptr costum deleter

### DIFF
--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -271,7 +271,7 @@ namespace cereal
       ptr.reset( reinterpret_cast<T *>( new ST() ),
           [=]( T * t )
           {
-            if( valid )
+            if( *valid )
               t->~T();
 
             delete reinterpret_cast<ST *>( t );


### PR DESCRIPTION
Correctly prevent calling destructor on unitialized data