### PR TITLE
Add inline specifiers to make_size_tag, prologue and epilogue

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -91,7 +91,7 @@ namespace cereal
 
       @relates SizeTag
       @ingroup Utility */
-  template <class T>
+  template <class T> inline
   SizeTag<T> make_size_tag( T && sz )
   {
     return {std::forward<T>(sz)};
@@ -104,14 +104,14 @@ namespace cereal
       state or output extra information for a type, specialize this function
       for the archive type and the types that require the extra information.
       @ingroup Internal */
-  template <class Archive, class T>
+  template <class Archive, class T> inline
   void prologue( Archive & /* archive */, T const & /* data */)
   { }
 
   //! Called after a type is serialized to tear down any special archive state
   //! for processing some type
   /*! @ingroup Internal */
-  template <class Archive, class T>
+  template <class Archive, class T> inline
   void epilogue( Archive & /* archive */, T const & /* data */)
   { }
 


### PR DESCRIPTION
It looks like that MSVC doesn't want to inline make_size_tag, and it has an impact on performance. I haven't seen the problem with prologue and epilogue functions. Anyway, just for the sake of consistency with other wrappers, inline looks sensible here.