### PR TITLE
Fix boost::variant compile error with clang 3.5.0/3.6.0

### DIFF
--- a/include/cereal/types/boost_variant.hpp
+++ b/include/cereal/types/boost_variant.hpp
@@ -79,8 +79,8 @@ namespace cereal
   } // namespace variant_detail
 
   //! Saving for boost::variant
-  template <class Archive, typename... VariantTypes> inline
-  void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, boost::variant<VariantTypes...> const & variant )
+  template <class Archive, typename VariantType1, typename... VariantTypes> inline
+  void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, boost::variant<VariantType1, VariantTypes...> const & variant )
   {
     int32_t which = variant.which();
     ar( CEREAL_NVP_("which", which) );
@@ -89,17 +89,17 @@ namespace cereal
   }
 
   //! Loading for boost::variant
-  template <class Archive, typename... VariantTypes> inline
-  void CEREAL_LOAD_FUNCTION_NAME( Archive & ar, boost::variant<VariantTypes...> & variant )
+  template <class Archive, typename VariantType1, typename... VariantTypes> inline
+  void CEREAL_LOAD_FUNCTION_NAME( Archive & ar, boost::variant<VariantType1, VariantTypes...> & variant )
   {
-    typedef typename boost::variant<VariantTypes...>::types types;
+    typedef typename boost::variant<VariantType1, VariantTypes...>::types types;
 
     int32_t which;
     ar( CEREAL_NVP_("which", which) );
     if(which >= boost::mpl::size<types>::value)
       throw Exception("Invalid 'which' selector when deserializing boost::variant");
 
-    variant_detail::load_variant<0, boost::variant<VariantTypes...>, VariantTypes...>(ar, which, variant);
+    variant_detail::load_variant<0, boost::variant<VariantType1, VariantTypes...>, VariantType1, VariantTypes...>(ar, which, variant);
   }
 } // namespace cereal
 


### PR DESCRIPTION
```
boost::variant<int> variant(10);
cereal::JSONOutputArchive oarchive(std::cout);
cereal::save(oarchive, variant);
```
```
note: candidate template ignored: substitution failure [with Archive = cereal::JSONOutputArchive, VariantTypes = <>]: too few template arguments for class template 'variant'
  void save( Archive & ar, boost::variant<VariantTypes...> const & variant )
```
see: https://llvm.org/bugs/show_bug.cgi?id=20890#c1