### PR TITLE
JSON updates

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -605,9 +605,9 @@ namespace cereal
       }
 
       //! Loads a value from the current node - bool overload
-      void loadValue(bool & val)        { search(); val = itsIteratorStack.back().value().GetBool_();   ++itsIteratorStack.back(); }
+      void loadValue(bool & val)        { search(); val = itsIteratorStack.back().value().GetBool_(); ++itsIteratorStack.back(); }
       //! Loads a value from the current node - int64 overload
-      void loadValue(int64_t & val)     { search(); val = itsIteratorStack.back().value().GetInt64();  ++itsIteratorStack.back(); }
+      void loadValue(int64_t & val)     { search(); val = itsIteratorStack.back().value().GetInt64(); ++itsIteratorStack.back(); }
       //! Loads a value from the current node - uint64 overload
       void loadValue(uint64_t & val)    { search(); val = itsIteratorStack.back().value().GetUint64(); ++itsIteratorStack.back(); }
       //! Loads a value from the current node - float overload

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -155,6 +155,8 @@ namespace cereal
       {
         if (itsNodeStack.top() == NodeType::InObject)
           itsWriter.EndObject();
+        else if (itsNodeStack.top() == NodeType::InArray)
+          itsWriter.EndArray();
       }
 
       //! Saves some binary data, encoded as a base64 string, with an optional name

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -414,7 +414,10 @@ namespace cereal
         itsReadStream(stream)
       {
         itsDocument.ParseStream<0>(itsReadStream);
-        itsIteratorStack.emplace_back(itsDocument.MemberBegin(), itsDocument.MemberEnd());
+        if (itsDocument.IsArray())
+          itsIteratorStack.emplace_back(itsDocument.Begin(), itsDocument.End());
+        else
+          itsIteratorStack.emplace_back(itsDocument.MemberBegin(), itsDocument.MemberEnd());
       }
 
       //! Loads some binary data, encoded as a base64 string
@@ -685,7 +688,10 @@ namespace cereal
       //! Loads the size for a SizeTag
       void loadSize(size_type & size)
       {
-        size = (itsIteratorStack.rbegin() + 1)->value().Size();
+        if (itsIteratorStack.size() == 1)
+          size = itsDocument.Size();
+        else
+          size = (itsIteratorStack.rbegin() + 1)->value().Size();
       }
 
       //! @}

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -636,7 +636,7 @@ namespace cereal
       template <class T> inline
       typename std::enable_if<sizeof(T) == sizeof(std::uint64_t) && !std::is_signed<T>::value, void>::type
       loadLong(T & lu){ loadValue( reinterpret_cast<std::uint64_t&>( lu ) ); }
-            
+
     public:
       //! Serialize a long if it would not be caught otherwise
       template <class T> inline

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -222,7 +222,7 @@ namespace cereal
       }
 
       //! Saves a bool to the current node
-      void saveValue(bool b)                { itsWriter.Bool_(b);                                                         }
+      void saveValue(bool b)                { itsWriter.Bool_(b);                                                        }
       //! Saves an int to the current node
       void saveValue(int i)                 { itsWriter.Int(i);                                                          }
       //! Saves a uint to the current node


### PR DESCRIPTION
This allows the JSON archive to close out arrays if they it is at the root. This occurs when a node would like to serialize itself as an Array in the root.