### PR TITLE
Barebones boost::variant unit test

### DIFF
--- a/unittests/boost_variant.cpp
+++ b/unittests/boost_variant.cpp
@@ -1,0 +1,74 @@
+/*
+  Copyright (c) 2015, Kyle Fleming
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES AND SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "common.hpp"
+#include <boost/test/unit_test.hpp>
+
+template <class IArchive, class OArchive>
+void test_boost_variant()
+{
+  boost::variant<int> o_bv;
+
+  std::ostringstream os;
+  {
+    OArchive oar(os);
+
+    oar(o_bv);
+  }
+
+  decltype( o_bv   ) i_bv;
+
+  std::istringstream is(os.str());
+  {
+    IArchive iar(is);
+
+    iar(i_bv);
+  }
+
+  BOOST_CHECK_EQUAL( i_bv   == o_bv,   true );
+}
+
+BOOST_AUTO_TEST_CASE( binary_boost_variant )
+{
+  test_boost_variant<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE( portable_binary_boost_variant )
+{
+  test_boost_variant<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE( xml_boost_variant )
+{
+  test_boost_variant<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE( json_boost_variant )
+{
+  test_boost_variant<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+

--- a/unittests/common.hpp
+++ b/unittests/common.hpp
@@ -47,6 +47,7 @@
 #include <cereal/types/complex.hpp>
 #include <cereal/types/chrono.hpp>
 #include <cereal/types/polymorphic.hpp>
+#include <cereal/types/boost_variant.hpp>
 
 #include <cereal/archives/binary.hpp>
 #include <cereal/archives/portable_binary.hpp>


### PR DESCRIPTION
I noticed there weren't any unit tests for boost::variant, so I added a very basic one that just serializes and deserializes. Obviously it's not comprehensive, but I think it's better than no unit test.