### PR TITLE
Additional MSVC JSON minimal fixes

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -753,40 +753,40 @@ namespace cereal
       that may be given data by the type about to be archived
 
       Minimal types do not start or finish nodes */
-  template <class T, traits::DisableIf<(std::is_arithmetic<T>::value) ||
-                                       traits::has_minimal_base_class_serialization<T, traits::has_minimal_output_serialization, JSONOutputArchive>::value ||
-                                       traits::has_minimal_output_serialization<T, JSONOutputArchive>::value> = traits::sfinae>
+  template <class T, traits::EnableIf<!std::is_arithmetic<T>::value,
+                                      !traits::has_minimal_base_class_serialization<T, traits::has_minimal_output_serialization, JSONOutputArchive>::value,
+                                      !traits::has_minimal_output_serialization<T, JSONOutputArchive>::value> = traits::sfinae>
   inline void prologue( JSONOutputArchive & ar, T const & )
   {
     ar.startNode();
   }
 
   //! Prologue for all other types for JSON archives
-  template <class T, traits::DisableIf<(std::is_arithmetic<T>::value) ||
-                                       traits::has_minimal_base_class_serialization<T, traits::has_minimal_input_serialization, JSONInputArchive>::value ||
-                                       traits::has_minimal_input_serialization<T, JSONInputArchive>::value> = traits::sfinae>
+  template <class T, traits::EnableIf<!std::is_arithmetic<T>::value,
+                                      !traits::has_minimal_base_class_serialization<T, traits::has_minimal_input_serialization, JSONInputArchive>::value,
+                                      !traits::has_minimal_input_serialization<T, JSONInputArchive>::value> = traits::sfinae>
   inline void prologue( JSONInputArchive & ar, T const & )
   {
     ar.startNode();
   }
 
   // ######################################################################
-  //! Epilogue for all other types other for JSON archives (except minimal types
+  //! Epilogue for all other types other for JSON archives (except minimal types)
   /*! Finishes the node created in the prologue
 
       Minimal types do not start or finish nodes */
-  template <class T, traits::DisableIf<(std::is_arithmetic<T>::value) ||
-                                       traits::has_minimal_base_class_serialization<T, traits::has_minimal_output_serialization, JSONOutputArchive>::value ||
-                                       traits::has_minimal_output_serialization<T, JSONOutputArchive>::value> = traits::sfinae>
+  template <class T, traits::EnableIf<!std::is_arithmetic<T>::value,
+                                      !traits::has_minimal_base_class_serialization<T, traits::has_minimal_output_serialization, JSONOutputArchive>::value,
+                                      !traits::has_minimal_output_serialization<T, JSONOutputArchive>::value> = traits::sfinae>
   inline void epilogue( JSONOutputArchive & ar, T const & )
   {
     ar.finishNode();
   }
 
   //! Epilogue for all other types other for JSON archives
-  template <class T, traits::DisableIf<(std::is_arithmetic<T>::value) ||
-                                       traits::has_minimal_base_class_serialization<T, traits::has_minimal_input_serialization, JSONInputArchive>::value ||
-                                       traits::has_minimal_input_serialization<T, JSONInputArchive>::value> = traits::sfinae>
+  template <class T, traits::EnableIf<!std::is_arithmetic<T>::value,
+                                      !traits::has_minimal_base_class_serialization<T, traits::has_minimal_input_serialization, JSONInputArchive>::value,
+                                      !traits::has_minimal_input_serialization<T, JSONInputArchive>::value> = traits::sfinae>
   inline void epilogue( JSONInputArchive & ar, T const & )
   {
     ar.finishNode();


### PR DESCRIPTION
Hey guys, the fixes in f451090 still did not solve USCiLab/cereal#217 when I tested it using VS Express 2013 for Desktop with Update 5 (msvc-12.0).

I changed the SFINAE logic to use `EnableIf` with AND conjunctions via the variadic arguments instead of `DisableIf` with the buggy OR conjunctions.  This fixed the issue for me and @sschaetz's example code now runs without issue.  To me this decreases the readability of the code, but at least it now works! :smile: