### PR TITLE
Make make_nvp member of archives

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -157,6 +157,23 @@ namespace cereal
           itsWriter.EndObject();
       }
 
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
+      }
+
       //! Saves some binary data, encoded as a base64 string, with an optional name
       /*! This will create a new node, optionally named, and insert a value that consists of
           the data encoded as a base64 string */
@@ -537,6 +554,23 @@ namespace cereal
       }
 
     public:
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
+      }
+
       //! Starts a new node, going into its proper iterator
       /*! This places an iterator for the next node to be parsed onto the iterator stack.  If the next
           node is an array, this will be a value iterator, otherwise it will be a member iterator.

--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -165,6 +165,23 @@ namespace cereal
         itsXML.clear();
       }
 
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
+      }
+
       //! Saves some binary data, encoded as a base64 string, with an optional name
       /*! This can be called directly by users and it will automatically create a child node for
           the current XML node, populate it with a base64 encoded string, and optionally name
@@ -235,7 +252,7 @@ namespace cereal
         const auto strValue = itsOS.str();
 
         // If the first or last character is a whitespace, add xml:space attribute
-        // the string always contains a '\0' added by std::ends, so the last character is at len-2 and an 'empty' 
+        // the string always contains a '\0' added by std::ends, so the last character is at len-2 and an 'empty'
         // string has a length of 1 or lower
         const auto len = strValue.length();
         if ( len > 1 && ( xml_detail::isWhitespace( strValue[0] ) || xml_detail::isWhitespace( strValue[len - 2] ) ) )
@@ -404,6 +421,23 @@ namespace cereal
           throw Exception("Could not detect cereal root node - likely due to empty or invalid input");
         else
           itsNodes.emplace( root );
+      }
+
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
       }
 
       //! Loads some binary data, encoded as a base64 string, optionally specified by some name

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -250,6 +250,23 @@ namespace cereal
         return *self;
       }
 
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
+      }
+
       /*! @name Boost Transition Layer
           Functionality that mirrors the syntax for Boost.  This is useful if you are transitioning
           a large project from Boost to cereal.  The preferred interface for cereal is using operator(). */
@@ -480,7 +497,7 @@ namespace cereal
           detail::StaticObject<detail::Versions>::getInstance().find( hash, detail::Version<T>::version );
 
         if( insertResult.second ) // insertion took place, serialize the version number
-          process( make_nvp<ArchiveType>("cereal_class_version", version) );
+          process( make_nvp("cereal_class_version", version) );
 
         return version;
       }
@@ -603,6 +620,23 @@ namespace cereal
       {
         process( std::forward<Types>( args )... );
         return *self;
+      }
+
+      // ######################################################################
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( std::string const & name, T && value )
+      {
+        return {name.c_str(), std::forward<T>(value)};
+      }
+
+      //! Creates a name value pair
+      /*! @relates NameValuePair */
+      template <class T> static inline
+      NameValuePair<T> make_nvp( const char * name, T && value )
+      {
+        return {name, std::forward<T>(value)};
       }
 
       /*! @name Boost Transition Layer
@@ -857,7 +891,7 @@ namespace cereal
         {
           std::uint32_t version;
 
-          process( make_nvp<ArchiveType>("cereal_class_version", version) );
+          process( make_nvp("cereal_class_version", version) );
           itsVersionedTypes.emplace_hint( lookupResult, hash, version );
 
           return version;

--- a/unittests/make_nvp_member.cpp
+++ b/unittests/make_nvp_member.cpp
@@ -1,0 +1,157 @@
+/*
+  Copyright (c) 2014, Randolph Voorhies, Shane Grant
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES AND SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include "common.hpp"
+#include <boost/test/unit_test.hpp>
+
+struct unordered_naming
+{
+  int x;
+  int xx;
+  int y;
+  int z;
+
+  template <class Archive>
+  void save( Archive & ar ) const
+  {
+    ar( Archive::make_nvp("x", x),
+        Archive::make_nvp("z", z),
+        Archive::make_nvp("y", y),
+        Archive::make_nvp("xx", xx) );
+  }
+
+  template <class Archive>
+  void load( Archive & ar )
+  {
+    ar( x,
+        Archive::make_nvp("y", y),
+        Archive::make_nvp("z", z),
+        Archive::make_nvp("xx", xx) );
+  }
+
+  bool operator==( unordered_naming const & other ) const
+  {
+    return x == other.x && xx == other.xx && y == other.y && z == other.z;
+  }
+};
+
+std::ostream& operator<<(std::ostream& os, unordered_naming const & s)
+{
+  os << "[x: " << s.x << " xx: " << s.xx << " y: " << s.y << " z: " << s.z << "]";
+  return os;
+}
+
+template <class IArchive, class OArchive>
+void test_unordered_loads()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  auto rngB = [&](){ return random_value<int>( gen ) % 2 == 0; };
+  auto rngI = [&](){ return random_value<int>( gen ); };
+  auto rngF = [&](){ return random_value<float>( gen ); };
+  auto rngD = [&](){ return random_value<double>( gen ); };
+  auto rngS = [&](){ return random_basic_string<char>( gen ); };
+
+  for(int ii=0; ii<100; ++ii)
+  {
+    auto const name1 = rngS();
+    auto const name2 = rngS();
+    auto const name3 = rngS();
+    auto const name4 = rngS();
+    auto const name5 = rngS();
+    auto const name6 = rngS();
+    auto const name7 = rngS();
+
+    int o_int1 = rngI();
+    double o_double2 = rngD();
+    std::vector<bool> o_vecbool3 = { rngB(), rngB(), rngB(), rngB(), rngB() };
+    int o_int4 = rngI();
+    int o_int5 = rngI();
+    int o_int6 = rngI();
+    std::pair<float, unordered_naming> o_un7;
+    o_un7.first = rngF();
+    o_un7.second.x = rngI();
+    o_un7.second.xx = rngI();
+    o_un7.second.y = rngI();
+    o_un7.second.z = rngI();
+
+    std::ostringstream os;
+    {
+      OArchive oar(os);
+
+      oar( OArchive::make_nvp( name1, o_int1 ),
+           OArchive::make_nvp( name2, o_double2 ),
+           OArchive::make_nvp( name3, o_vecbool3 ),
+           OArchive::make_nvp( name4, o_int4 ),
+           OArchive::make_nvp( name5, o_int5 ),
+           OArchive::make_nvp( name6, o_int6 ),
+           OArchive::make_nvp( name7, o_un7 ) );
+    }
+
+    decltype(o_int1) i_int1;
+    decltype(o_double2) i_double2;
+    decltype(o_vecbool3) i_vecbool3;
+    decltype(o_int4) i_int4;
+    decltype(o_int5) i_int5;
+    decltype(o_int6) i_int6;
+    decltype(o_un7) i_un7;
+
+    std::istringstream is(os.str());
+    {
+      IArchive iar(is);
+
+      iar( IArchive::make_nvp( name7, i_un7 ),
+           IArchive::make_nvp( name2, i_double2 ),
+           IArchive::make_nvp( name4, i_int4 ),
+           IArchive::make_nvp( name3, i_vecbool3 ),
+           IArchive::make_nvp( name1, i_int1 ),
+           IArchive::make_nvp( name5, i_int5 ),
+           i_int6 );
+    }
+
+    BOOST_CHECK_EQUAL(o_int1, i_int1);
+    BOOST_CHECK_CLOSE(o_double2 , o_double2, 1e-5);
+    BOOST_CHECK_EQUAL(o_vecbool3.size(), i_vecbool3.size());
+    BOOST_CHECK_EQUAL_COLLECTIONS(i_vecbool3.begin(),    i_vecbool3.end(),    o_vecbool3.begin(),  o_vecbool3.end());
+    BOOST_CHECK_EQUAL(o_int4, i_int4);
+    BOOST_CHECK_EQUAL(o_int5, i_int5);
+    BOOST_CHECK_EQUAL(o_int6, i_int6);
+    BOOST_CHECK_EQUAL(o_un7.first, i_un7.first);
+    BOOST_CHECK_EQUAL(o_un7.second, i_un7.second);
+  }
+}
+
+BOOST_AUTO_TEST_CASE( xml_unordered_loads )
+{
+  test_unordered_loads<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+BOOST_AUTO_TEST_CASE( json_unordered_loads )
+{
+  test_unordered_loads<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+


### PR DESCRIPTION
There are instances where, in a given compilation unit, we never want to serialize a cereal-serializable type but only use it. 

However, if the type has a serialize() member that uses ::cereal::make_nvp, the cereal
header must  be included.

We propose adding make_nvp to the archives themselves so a serializable type is usable without including any cereal headers. But at the same time it will still be possible to maintain the serialization code as a member of the type, which is preferable over external definition of the serialization code in a separate file.

The modified unit-test make_nvp_member.cpp illustrates the idea: It is now possible to implement the type `unordered_naming` without the type knowing anything about cereal. To achieve this the archive concept is extended with the make_nvp method.