### PR TITLE
Make `double` roundtrip when serializing and deserializing to JSON

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -108,7 +108,7 @@ namespace cereal
           static Options Default(){ return Options(); }
 
           //! Default options with no indentation
-          static Options NoIndent(){ return Options( std::numeric_limits<double>::max_digits10, IndentChar::space, 0 ); }
+          static Options NoIndent(){ return Options( JSONWriter::kDefaultMaxDecimalPlaces, IndentChar::space, 0 ); }
 
           //! The character to use for indenting
           enum class IndentChar : char
@@ -124,7 +124,7 @@ namespace cereal
               @param indentChar The type of character to indent with
               @param indentLength The number of indentChar to use for indentation
                              (0 corresponds to no indentation) */
-          explicit Options( int precision = std::numeric_limits<double>::max_digits10,
+          explicit Options( int precision = JSONWriter::kDefaultMaxDecimalPlaces,
                             IndentChar indentChar = IndentChar::space,
                             unsigned int indentLength = 4 ) :
             itsPrecision( precision ),
@@ -420,7 +420,7 @@ namespace cereal
         itsNextName( nullptr ),
         itsReadStream(stream)
       {
-        itsDocument.ParseStream<0>(itsReadStream);
+        itsDocument.ParseStream<rapidjson::kParseFullPrecisionFlag>(itsReadStream);
         if (itsDocument.IsArray())
           itsIteratorStack.emplace_back(itsDocument.Begin(), itsDocument.End());
         else

--- a/include/cereal/external/rapidjson/reader.h
+++ b/include/cereal/external/rapidjson/reader.h
@@ -23,6 +23,7 @@
 #include "internal/meta.h"
 #include "internal/stack.h"
 #include "internal/strtod.h"
+#include <limits>
 
 #if defined(CEREAL_RAPIDJSON_SIMD) && defined(_MSC_VER)
 #include <intrin.h>
@@ -699,12 +700,16 @@ private:
     }
 
     template<unsigned parseFlags, typename InputStream, typename Handler>
-    void ParseNull(InputStream& is, Handler& handler) {
+    void ParseNullOrNan(InputStream& is, Handler& handler) {
         CEREAL_RAPIDJSON_ASSERT(is.Peek() == 'n');
         is.Take();
 
         if (CEREAL_RAPIDJSON_LIKELY(Consume(is, 'u') && Consume(is, 'l') && Consume(is, 'l'))) {
             if (CEREAL_RAPIDJSON_UNLIKELY(!handler.Null()))
+                CEREAL_RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+        }
+        else if (Consume(is, 'a') && Consume(is, 'n')) {
+            if (CEREAL_RAPIDJSON_UNLIKELY(!handler.Double( std::numeric_limits<double>::quiet_NaN() )))
                 CEREAL_RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
         }
         else
@@ -1178,6 +1183,12 @@ private:
                     significandDigit++;
                 }
         }
+        else if (CEREAL_RAPIDJSON_UNLIKELY(Consume(s, 'i')) && Consume(s, 'n') && Consume(s, 'f')) {
+            double inf = std::numeric_limits<double>::infinity();
+            if (CEREAL_RAPIDJSON_UNLIKELY(!handler.Double(minus ? -inf : inf)))
+                CEREAL_RAPIDJSON_PARSE_ERROR(kParseErrorTermination, startOffset);
+            return;
+        }
         else
             CEREAL_RAPIDJSON_PARSE_ERROR(kParseErrorValueInvalid, s.Tell());
 
@@ -1369,7 +1380,7 @@ private:
     template<unsigned parseFlags, typename InputStream, typename Handler>
     void ParseValue(InputStream& is, Handler& handler) {
         switch (is.Peek()) {
-            case 'n': ParseNull  <parseFlags>(is, handler); break;
+            case 'n': ParseNullOrNan<parseFlags>(is, handler); break;
             case 't': ParseTrue  <parseFlags>(is, handler); break;
             case 'f': ParseFalse <parseFlags>(is, handler); break;
             case '"': ParseString<parseFlags>(is, handler); break;

--- a/include/cereal/external/rapidjson/writer.h
+++ b/include/cereal/external/rapidjson/writer.h
@@ -319,8 +319,25 @@ protected:
     }
 
     bool WriteDouble(double d) {
-        if (internal::Double(d).IsNanOrInf())
+        if (internal::Double(d).IsNanOrInf()) {
+            if (internal::Double(d).IsNan()) {
+                PutReserve(*os_, 3);
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('n'));
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('a'));
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('n'));
+            } else {
+                if (internal::Double(d).Sign()) {
+                    PutReserve(*os_, 4);
+                    PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('-'));
+                } else {
+                    PutReserve(*os_, 3);
+                }
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('i'));
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('n'));
+                PutUnsafe(*os_, static_cast<typename TargetEncoding::Ch>('f'));
+            }
             return false;
+        }
         
         char buffer[25];
         char* end = internal::dtoa(d, buffer, maxDecimalPlaces_);


### PR DESCRIPTION
The current develop branch of cereal has several problems with serialization and deserialization of `double` values:

1. Values are **truncated** at 17 decimal digits (this is **not** the same as having 17 decimal digits of *precision*). For example, `1e-20` is serialized as `0.0`. The setting to avoid truncation is given by `rapidjson::Writer<>::kDefaultMaxDecimalPlaces` and is equal to 324 decimal placed (not 17). I think you may have misunderstood the `SetMaxDecimalPlaces()` option of the current rapidjson writer.

2. The special values `nan`, `inf` and `-inf` are not serialized by the current version of rapidjson (nothing is printed at all, resulting in an invalid json representation that cannot be deserialized, i.e., crashes on deserialization).

3. With the current settings (without `rapidjson::kParseFullPrecisionFlag`), the deserialization loses up to 3 bits of precision. For example, deserializing `0.9868011474609375` becomes `0.9868011474609376`.

This pull request presents a possible fix to all of these issues (1 and 3 being rather trivial changes to json.hpp)

By the way, note that the version of rapidjson you currently include in the develop branch is not 1.0.2, but a rather recent version from the master branch.