### PR TITLE
Provide manual implementations for to_string() & friends for Android NDK + GCC

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -39,6 +39,13 @@
 #include <cstdint>
 #include <functional>
 
+// Allow a custom implementation of std::to_string, std::stol, and other
+// functions. As an example for when this is needed: GCC in Android NDK
+// does not implement std::to_string.
+#if defined(CEREAL_IMPLEMENT_TO_STRING)
+#   include <cereal/external/to_string.hpp>
+#endif // defined(CEREAL_IMPLEMENT_TO_STRING)
+
 #include <cereal/macros.hpp>
 #include <cereal/details/traits.hpp>
 #include <cereal/details/helpers.hpp>

--- a/include/cereal/external/to_string.hpp
+++ b/include/cereal/external/to_string.hpp
@@ -1,0 +1,64 @@
+#ifndef CEREAL_EXTERNAL_TO_STRING_HPP_
+#define CEREAL_EXTERNAL_TO_STRING_HPP_
+
+#include <cstdlib>
+#include <string>
+#include <sstream>
+
+namespace std
+{
+    inline long double strtold(const char * str, char ** str_end)
+    {
+        return strtod(str, str_end);
+    }
+
+    template<typename T>
+    std::string to_string(T const& data)
+    {
+        std::ostringstream ss;
+        ss << data;
+        return ss.str();
+    }
+
+    inline int stoi(const std::string& str, std::size_t* pos = 0, int base = 10)
+    {
+        return strtol(str.c_str(), nullptr, base);
+    }
+
+    inline long stol(const std::string& str, std::size_t* pos = 0, int base = 10)
+    {
+        return strtol(str.c_str(), nullptr, base);
+    }
+
+    inline long long stoll(const std::string& str, std::size_t* pos = 0, int base = 10)
+    {
+        return strtoll(str.c_str(), nullptr, base);
+    }
+
+    inline unsigned long stoul(const std::string& str, std::size_t* pos = 0, int base = 10)
+    {
+        return strtoul(str.c_str(), nullptr, base);
+    }
+
+    inline unsigned long long stoull(const std::string& str, std::size_t* pos = 0, int base = 10)
+    {
+        return strtoull(str.c_str(), nullptr, base);
+    }
+
+    inline float stof(const std::string& str, std::size_t* pos = 0)
+    {
+        return strtof(str.c_str(), nullptr);
+    }
+
+    inline double stod(const std::string& str, std::size_t* pos = 0)
+    {
+        return strtod(str.c_str(), nullptr);
+    }
+
+    inline long double stold(const std::string& str, std::size_t* pos = 0)
+    {
+        return strtold(str.c_str(), nullptr);
+    }
+}
+
+#endif // CEREAL_EXTERNAL_TO_STRING_HPP_


### PR DESCRIPTION
By defining `CEREAL_IMPLEMENT_TO_STRING` via the preprocessor, self-implemented
versions of the following STL functions will be provided.

* `std::strtold()`
* `std::to_string()`
* `std::stoi()`
* `std::stol()`
* `std::stoll()`
* `std::stoul()`
* `std::stoull()`
* `std::stof()`
* `std::stod()`
* `std::stold()`

The specific use case for this is using Android NDK with C++11 or higher
and on the GCC 4.9 + GNU STL toolchain/library. At the moment, implementations
of these libraries are not provided by this toolchain.