### PR TITLE
Convenience macro to map save/load minimal to iostream operators

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -38,11 +38,31 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <sstream>
 
 #include <cereal/macros.hpp>
 #include <cereal/details/traits.hpp>
 #include <cereal/details/helpers.hpp>
 #include <cereal/types/base_class.hpp>
+
+#define CEREAL_SERIALIZE_MINIMAL_USING_STREAMS(type) \
+  namespace cereal \
+  { \
+    template<typename Archive> \
+    std::string save_minimal(Archive const&, type const& obj) \
+    { \
+      std::ostringstream ss; \
+      ss << obj; \
+      return ss.str(); \
+    } \
+      \
+    template<typename Archive> \
+    void load_minimal(Archive const&, type& obj, std::string const& value) \
+    { \
+      std::istringstream ss{value}; \
+      ss >> obj; \
+    } \
+  }
 
 namespace cereal
 {


### PR DESCRIPTION
Often times libraries will provide classes with custom iostream operators (such as `operator<<` and `operator>>`). However, out of the box, cereal will not use these.

A macro named `CEREAL_SERIALIZE_MINIMAL_USING_STREAMS()` has been added as a convenient way of creating corresponding implementations of the `save_minimal()` and `load_minimal()` free functions. Their implementation utilizes std::stringstream to box/unbox a specified custom type between
std::string and its actual type.

It's considered boilerplate to have to continuously implement these two functions for types that already define methods to marshal their data to and from strings.

**NOTE**

I have not yet bothered with unit tests because I want to make sure from a design perspective that everyone is OK with this. I am not 100% satisfied with this solution myself, as I wish iostream support was more intrinsic to archives, however I feel that kind of redesign is far less trivial.

Definitely want opinions on this. Thanks in advance.
