### PR TITLE
WIP: Introduction of cereal::make_optional_nvp()

### DIFF
--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -759,6 +759,30 @@ namespace cereal
   { }
 
   // ######################################################################
+  //! Prologue for NVPs for XML output archives
+  /*! NVPs do not start or finish nodes - they just set up the names */
+  template <class T> inline
+     void prologue(XMLOutputArchive &, OptionalNameValuePair<T> const &)
+  { }
+
+  //! Prologue for NVPs for XML input archives
+  template <class T> inline
+     void prologue(XMLInputArchive &, OptionalNameValuePair<T> const &)
+  { }
+
+  // ######################################################################
+  //! Epilogue for NVPs for XML output archives
+  /*! NVPs do not start or finish nodes - they just set up the names */
+  template <class T> inline
+     void epilogue(XMLOutputArchive &, OptionalNameValuePair<T> const &)
+  { }
+
+  //! Epilogue for NVPs for XML input archives
+  template <class T> inline
+     void epilogue(XMLInputArchive &, OptionalNameValuePair<T> const &)
+  { }
+
+  // ######################################################################
   //! Prologue for SizeTags for XML output archives
   /*! SizeTags do not start or finish nodes */
   template <class T> inline

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -65,6 +65,39 @@ namespace cereal
     return {name, std::forward<T>(value)};
   }
 
+  template <class T>
+  OptionalNameValuePair<T> make_optional_nvp(std::string const& name, T&& value)
+  {
+     static std::remove_reference_t<T> const defaultValue{};
+     return{name.c_str(), std::forward<T>(value), defaultValue};
+  }
+
+  template <class T, class V>
+  OptionalNameValuePair<T> make_optional_nvp(std::string const& name, T&& value,
+     V const& defaultValue)
+  {
+     return{name.c_str(), std::forward<T>(value), defaultValue};
+  }
+
+  template <class T>
+  OptionalNameValuePair<T> make_optional_nvp(char const* name, T&& value)
+  {
+     static std::remove_reference_t<T> const defaultValue{};
+     return{name, std::forward<T>(value), defaultValue};
+  }
+
+  template <class T, class V>
+  OptionalNameValuePair<T> make_optional_nvp(char const* name, T&& value,
+     V const& defaultValue)
+  {
+     return{name, std::forward<T>(value), defaultValue};
+  }
+
+  //! Creates a name value pair for the variable T with the same name as the variable
+  /*! @relates NameValuePair
+      @ingroup Utility */
+  #define CEREAL_OPTIONAL_NVP(T, ...) ::cereal::make_optional_nvp(#T, T, __VA_ARGS__)
+
   //! Creates a name value pair for the variable T with the same name as the variable
   /*! @relates NameValuePair
       @ingroup Utility */

--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -134,7 +134,7 @@ namespace cereal
   template <class T>
   class NameValuePair : detail::NameValuePairCore
   {
-    private:
+    protected:
       // If we get passed an array, keep the type as is, otherwise store
       // a reference if we were passed an l value reference, else copy the value
       using Type = typename std::conditional<std::is_array<typename std::remove_reference<T>::type>::value,
@@ -164,6 +164,19 @@ namespace cereal
       Type value;
   };
 
+  template<class T>
+  class OptionalNameValuePair : public NameValuePair<T>
+  {
+  public:
+     template<class V>
+     OptionalNameValuePair(char const* name, T&& value, V const& defaultValue_)
+        : NameValuePair<T>(name, std::forward<T>(value))
+        , defaultValue(defaultValue_)
+     {}
+
+     std::remove_reference_t<T> defaultValue{};
+  };
+
   //! A specialization of make_nvp<> that simply forwards the value for binary archives
   /*! @relates NameValuePair
       @internal */
@@ -189,6 +202,19 @@ namespace cereal
   {
     return {name, std::forward<T>(value)};
   }
+
+  ////! A specialization of make_optional_nvp<> that actually creates an nvp for non-binary archives
+  ///*! @relates NameValuePair
+  //@internal */
+  //template<class Archive, class T>
+  //typename
+  //std::enable_if<!std::is_same<Archive, ::cereal::BinaryInputArchive>::value &&
+  //               !std::is_same<Archive, ::cereal::BinaryOutputArchive>::value,
+  //OptionalNameValuePair<T> >::type
+  //make_optional_nvp(const char * name, T && value, T const& defaultValue = T{})
+  //{
+  //   return{name, std::forward<T>(value), defaultValue};
+  //}
 
   //! Convenience for creating a templated NVP
   /*! For use in internal generic typing functions which have an


### PR DESCRIPTION
Allows a default value to be assigned to name value pairs that are not found by an input archive. For an NVP representing a value of type T, the default value assigned if that NVP is missing is `T{}` or whatever was specified explicitly. Example:

```
ar(CEREAL_OPTIONAL_NVP(myfoo, "default_value"));
ar(cereal::make_optional_nvp("myfoo_different", myfoo, "default_value"));
```

This PR is a work in progress. The overall design of this needs review. Corresponding issue is #326 and #30.

Concerning design, this is a very simple solution. An extra step that should be taken is to clean up the exception throw site. The archive itself shouldn't throw, but instead use an error code. The corresponding load function for the NVP object should throw instead. This allows the optional NVP functions to not be impacted performance-wise by the throwing that is ultimately swallowed simply to set the default value.
