### PR TITLE
Register of chainable relations fix

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -232,7 +232,7 @@ namespace cereal
         }
 
         // Find all chainable unregistered relations
-        std::map<std::type_index, std::pair<std::type_index, std::vector<PolymorphicCaster const *>>> unregisteredRelations;
+        std::multimap<std::type_index, std::pair<std::type_index, std::vector<PolymorphicCaster const *>>> unregisteredRelations;
         {
           auto checkRelation = [](std::type_index const & baseInfo, std::type_index const & derivedInfo)
           {

--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -244,10 +244,10 @@ namespace cereal
             };
 
             Relations unregisteredRelations;
-            for( auto baseIt : baseMap )
-              for( auto derivedIt : baseIt.second )
+            for( auto const & baseIt : baseMap )
+              for( auto const & derivedIt : baseIt.second )
               {
-                for( auto otherBaseIt : baseMap )
+                for( auto const & otherBaseIt : baseMap )
                 {
                   if( baseIt.first == otherBaseIt.first ) // only interested in chained relations
                     continue;
@@ -286,7 +286,7 @@ namespace cereal
           {
             unregisteredRelations = findChainableRelations();
             // Insert chained relations
-            for( auto it : unregisteredRelations )
+            for( auto const & it : unregisteredRelations )
             {
               auto & derivedMap = baseMap.find( it.first )->second;
               derivedMap[it.second.first] = it.second.second;


### PR DESCRIPTION
There is a case when we could find several different relations to write to 'unregisteredRelations' map with one 'otherBase'.