### PR TITLE
Avoid accidentally using the "check" macro on OSX

### DIFF
--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -1180,9 +1180,9 @@ namespace cereal
       struct shared_from_this_wrapper
       {
         template <class U>
-        static auto check( U const & t ) -> decltype( ::cereal::access::shared_from_this(t), std::true_type() );
+        static auto (check)( U const & t ) -> decltype( ::cereal::access::shared_from_this(t), std::true_type() );
 
-        static auto check( ... ) -> decltype( std::false_type() );
+        static auto (check)( ... ) -> decltype( std::false_type() );
 
         template <class U>
         static auto get( U const & t ) -> decltype( t.shared_from_this() );
@@ -1191,7 +1191,7 @@ namespace cereal
 
     //! Determine if T or any base class of T has inherited from std::enable_shared_from_this
     template<class T>
-    struct has_shared_from_this : decltype(detail::shared_from_this_wrapper::check(std::declval<T>()))
+    struct has_shared_from_this : decltype((detail::shared_from_this_wrapper::check)(std::declval<T>()))
     { };
 
     //! Get the type of the base class of T which inherited from std::enable_shared_from_this


### PR DESCRIPTION
Fix for #341, #273, and #104.  Replace usages of "check(" with
"(check)(", which will prevent us from colliding with the macro defined
in OSX's Assert macros.