### PR TITLE
Use statics initialization on demand fixed #331

### DIFF
--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -115,6 +115,7 @@ namespace cereal
           return LockGuard{};
           #endif
         }
+
       private:
         static T & instance;
     };

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -120,7 +120,6 @@ namespace cereal
     };
 
     template <class T> T & StaticObject<T>::instance = StaticObject<T>::create();
-
   } // namespace detail
 } // namespace cereal
 

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -109,7 +109,7 @@ namespace cereal
         static LockGuard lock()
         {
           #if CEREAL_THREAD_SAFE
-          std::mutex instanceMutex;
+          static std::mutex instanceMutex;
           return LockGuard{instanceMutex};
           #else
           return LockGuard{};

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -73,7 +73,7 @@ namespace cereal
         static T & create()
         {
           static T t;
-          instantiate(t);
+          instantiate(instance);
           return t;
         }
 
@@ -115,8 +115,11 @@ namespace cereal
           return LockGuard{};
           #endif
         }
-
+      private:
+        static T & instance;
     };
+
+    template <class T> T & StaticObject<T>::instance = StaticObject<T>::create();
 
   } // namespace detail
 } // namespace cereal

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -73,7 +73,7 @@ namespace cereal
         static T & create()
         {
           static T t;
-          instantiate(instance);
+          instantiate(t);
           return t;
         }
 
@@ -109,23 +109,15 @@ namespace cereal
         static LockGuard lock()
         {
           #if CEREAL_THREAD_SAFE
+          std::mutex instanceMutex;
           return LockGuard{instanceMutex};
           #else
           return LockGuard{};
           #endif
         }
 
-      private:
-        static T & instance;
-        #if CEREAL_THREAD_SAFE
-        static std::mutex instanceMutex;
-        #endif
     };
 
-    template <class T> T & StaticObject<T>::instance = StaticObject<T>::create();
-    #if CEREAL_THREAD_SAFE
-    template <class T> std::mutex StaticObject<T>::instanceMutex;
-    #endif
   } // namespace detail
 } // namespace cereal
 


### PR DESCRIPTION
Fixed crash CEREAL_THREAD_SAFE=1 with polymorphic class. Crash happened because StaticObject<T>::instanceMutex not initialized when StaticObject<T>::lock() called for the first time. Basically it is better to use static vars inside static functions to have predefined order of construction like it is done in StaticObject<T>::getInstance(), which calls create and forces instantiation at pre-execution time.
Also in this commit removed static T &instance; since it is possible that there were be two instances created
1) template <class T> T & StaticObject<T>::instance = StaticObject<T>::create();
2) inside StaticObject<T>::create()