### PR TITLE
Replaced hardcoded rapidsjon namespacing with CEREAL_RAPIDJSON_NAMESPACE

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -96,8 +96,8 @@ namespace cereal
   {
     enum class NodeType { StartObject, InObject, StartArray, InArray };
 
-    using WriteStream = rapidjson::OStreamWrapper;
-    using JSONWriter = rapidjson::PrettyWriter<WriteStream>;
+    using WriteStream = CEREAL_RAPIDJSON_NAMESPACE::OStreamWrapper;
+    using JSONWriter = CEREAL_RAPIDJSON_NAMESPACE::PrettyWriter<WriteStream>;
 
     public:
       /*! @name Common Functionality
@@ -242,7 +242,7 @@ namespace cereal
       //! Saves a double to the current node
       void saveValue(double d)              { itsWriter.Double(d);                                                       }
       //! Saves a string to the current node
-      void saveValue(std::string const & s) { itsWriter.String(s.c_str(), static_cast<rapidjson::SizeType>( s.size() )); }
+      void saveValue(std::string const & s) { itsWriter.String(s.c_str(), static_cast<CEREAL_RAPIDJSON_NAMESPACE::SizeType>( s.size() )); }
       //! Saves a const char * to the current node
       void saveValue(char const * s)        { itsWriter.String(s);                                                       }
       //! Saves a nullptr to the current node
@@ -406,11 +406,11 @@ namespace cereal
   class JSONInputArchive : public InputArchive<JSONInputArchive>, public traits::TextArchive
   {
     private:
-      using ReadStream = rapidjson::IStreamWrapper;
-      typedef rapidjson::GenericValue<rapidjson::UTF8<>> JSONValue;
+      using ReadStream = CEREAL_RAPIDJSON_NAMESPACE::IStreamWrapper;
+      typedef CEREAL_RAPIDJSON_NAMESPACE::GenericValue<CEREAL_RAPIDJSON_NAMESPACE::UTF8<>> JSONValue;
       typedef JSONValue::ConstMemberIterator MemberIterator;
       typedef JSONValue::ConstValueIterator ValueIterator;
-      typedef rapidjson::Document::GenericValue GenericValue;
+      typedef CEREAL_RAPIDJSON_NAMESPACE::Document::GenericValue GenericValue;
 
     public:
       /*! @name Common Functionality
@@ -713,7 +713,7 @@ namespace cereal
       const char * itsNextName;               //!< Next name set by NVP
       ReadStream itsReadStream;               //!< Rapidjson write stream
       std::vector<Iterator> itsIteratorStack; //!< 'Stack' of rapidJSON iterators
-      rapidjson::Document itsDocument;        //!< Rapidjson document
+	  CEREAL_RAPIDJSON_NAMESPACE::Document itsDocument;        //!< Rapidjson document
   };
 
   // ######################################################################


### PR DESCRIPTION
I've ran into a problem in which I had another library that uses RapidJSON too, but an older version of it and that caused runtime errors.

I noticed Cereal uses CEREAL_RAPIDJSON_NAMESPACE macro to define RapidJSON's namepsace, but some places had the namespace "rapidjson" hardcoded, so I replaced them with the macro.

This way it's enough to only change the macro to put Cereal's RapidJSON in a different namespace.