### PR TITLE
Fix bitset loading when bits are already set.

### DIFF
--- a/include/cereal/types/bitset.hpp
+++ b/include/cereal/types/bitset.hpp
@@ -148,6 +148,8 @@ namespace cereal
         std::uint8_t chunk = 0;
         std::uint8_t mask  = 0;
 
+        bits.reset();
+
         // Load one chunk at a time, rotating through the chunk
         // to set bits in the bitset
         for( std::size_t i = 0; i < N; ++i )
@@ -160,8 +162,6 @@ namespace cereal
 
           if( chunk & mask )
             bits[i] = 1;
-          else
-            bits[i] = 0;
 
           mask >>= 1;
         }

--- a/include/cereal/types/bitset.hpp
+++ b/include/cereal/types/bitset.hpp
@@ -160,6 +160,8 @@ namespace cereal
 
           if( chunk & mask )
             bits[i] = 1;
+          else
+            bits[i] = 0;
 
           mask >>= 1;
         }

--- a/unittests/bitset.cpp
+++ b/unittests/bitset.cpp
@@ -44,6 +44,7 @@ void test_bitset()
     std::bitset<65> o_bit65( rng65() );
     std::bitset<256> o_bit256( rng256() );
     std::bitset<512> o_bit512( rng512() );
+    std::bitset<32>  o_bit32_low( 0 );
 
     std::ostringstream os;
     {
@@ -53,12 +54,14 @@ void test_bitset()
       oar(o_bit65);
       oar(o_bit256);
       oar(o_bit512);
+      oar(o_bit32_low);
     }
 
     std::bitset<32>  i_bit32;
     std::bitset<65>  i_bit65;
     std::bitset<256> i_bit256;
     std::bitset<512> i_bit512;
+    std::bitset<32>  i_bit32_low( 0xffffffff );
 
     std::istringstream is(os.str());
     {
@@ -68,12 +71,15 @@ void test_bitset()
       iar(i_bit65);
       iar(i_bit256);
       iar(i_bit512);
+      iar(i_bit32_low);
     }
 
     BOOST_CHECK_EQUAL( o_bit32, i_bit32 );
     BOOST_CHECK_EQUAL( o_bit65, i_bit65 );
     BOOST_CHECK_EQUAL( o_bit256, i_bit256 );
     BOOST_CHECK_EQUAL( o_bit512, i_bit512 );
+
+    BOOST_CHECK_EQUAL( o_bit32_low, i_bit32_low );
   }
 }
 


### PR DESCRIPTION
While investigating porting our codebase from Boost.Serialization, noticed this issue. When loading into a bitset that may already have bits set high, the de-serialization won't properly set any bits that are low.