### PR TITLE
Don't use C style casts

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -645,7 +645,7 @@ namespace cereal
       //! Binding for non abstract types
       void bind(std::false_type) const
 	    {
-		    instantiate_polymorphic_binding((T*) 0, 0, Tag{}, adl_tag{});
+                   instantiate_polymorphic_binding(static_cast<T*>(0), 0, Tag{}, adl_tag{});
       }
 
       //! Binding for abstract types

--- a/include/cereal/external/base64.hpp
+++ b/include/cereal/external/base64.hpp
@@ -50,10 +50,10 @@ namespace cereal
       while (in_len--) {
         char_array_3[i++] = *(bytes_to_encode++);
         if (i == 3) {
-          char_array_4[0] = (unsigned char) ((char_array_3[0] & 0xfc) >> 2);
-          char_array_4[1] = (unsigned char) ( ( ( char_array_3[0] & 0x03 ) << 4 ) + ( ( char_array_3[1] & 0xf0 ) >> 4 ) );
-          char_array_4[2] = (unsigned char) ( ( ( char_array_3[1] & 0x0f ) << 2 ) + ( ( char_array_3[2] & 0xc0 ) >> 6 ) );
-          char_array_4[3] = (unsigned char) ( char_array_3[2] & 0x3f );
+          char_array_4[0] = static_cast<unsigned char>((char_array_3[0] & 0xfc) >> 2);
+          char_array_4[1] = static_cast<unsigned char>( ( ( char_array_3[0] & 0x03 ) << 4 ) + ( ( char_array_3[1] & 0xf0 ) >> 4 ) );
+          char_array_4[2] = static_cast<unsigned char>( ( ( char_array_3[1] & 0x0f ) << 2 ) + ( ( char_array_3[2] & 0xc0 ) >> 6 ) );
+          char_array_4[3] = static_cast<unsigned char>( char_array_3[2] & 0x3f );
 
           for(i = 0; (i <4) ; i++)
             ret += chars[char_array_4[i]];
@@ -95,7 +95,7 @@ namespace cereal
         char_array_4[i++] = encoded_string[in_]; in_++;
         if (i ==4) {
           for (i = 0; i <4; i++)
-            char_array_4[i] = (unsigned char) chars.find( char_array_4[i] );
+            char_array_4[i] = static_cast<unsigned char>(chars.find( char_array_4[i] ));
 
           char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
           char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
@@ -112,7 +112,7 @@ namespace cereal
           char_array_4[j] = 0;
 
         for (j = 0; j <4; j++)
-          char_array_4[j] = (unsigned char) chars.find( char_array_4[j] );
+          char_array_4[j] = static_cast<unsigned char>(chars.find( char_array_4[j] ));
 
         char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
         char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);

--- a/sandbox/sandbox.cpp
+++ b/sandbox/sandbox.cpp
@@ -651,9 +651,9 @@ int main()
     iar( d1 );
     assert( d1->x == 4 && d1->y == 3 );
     iar( d2 );
-    assert( ((Derived*)d2.get())->x == 5 && ((Derived*)d2.get())->y == 4 );
+    assert( static_cast<Derived*>(d2.get())->x == 5 && static_cast<Derived*>(d2.get())->y == 4 );
     iar( d3 );
-    assert( ((Derived*)d3.get())->x == 6 && ((Derived*)d3.get())->y == 5 );
+    assert( static_cast<Derived*>(d3.get())->x == 6 && static_cast<Derived*>(d3.get())->y == 5 );
   }
 
   {

--- a/sandbox/sandbox_json.cpp
+++ b/sandbox/sandbox_json.cpp
@@ -320,13 +320,13 @@ enum Bla
 template <class Archive>
 void save( Archive & ar, Bla const & b )
 {
-  ar( (const int &)b );
+  ar( static_cast<const int &>(b) );
 }
 
 template <class Archive>
 void load( Archive & ar, Bla & b )
 {
-  ar( (int&)b );
+  ar( static_cast<int&>(b) );
 }
 
 CEREAL_SPECIALIZE_FOR_ALL_ARCHIVES( Bla, cereal::specialization::non_member_load_save )

--- a/unittests/pod.cpp
+++ b/unittests/pod.cpp
@@ -132,7 +132,7 @@ void test_pod()
     BOOST_CHECK_EQUAL(i_int32  , o_int32);
     BOOST_CHECK_EQUAL(i_uint64 , o_uint64);
     BOOST_CHECK_EQUAL(i_int64  , o_int64);
-    BOOST_CHECK_CLOSE(i_float  , o_float,  (float)1e-5);
+    BOOST_CHECK_CLOSE(i_float  , o_float,  static_cast<float>(1e-5));
     BOOST_CHECK_CLOSE(i_double , o_double, 1e-5);
 
     BOOST_CHECK_CLOSE(i_long_double, o_long_double, 1e-5);

--- a/unittests/polymorphic.cpp
+++ b/unittests/polymorphic.cpp
@@ -313,13 +313,13 @@ void test_polymorphic()
     #endif
 
     BOOST_CHECK_EQUAL(i_shared.get(), i_locked.get());
-    BOOST_CHECK_EQUAL(*((PolyDerived*)i_shared.get()), *((PolyDerived*)o_shared.get()));
-    BOOST_CHECK_EQUAL(*((PolyDerived*)i_shared.get()), *((PolyDerived*)i_locked.get()));
-    BOOST_CHECK_EQUAL(*((PolyDerived*)i_locked.get()), *((PolyDerived*)o_locked.get()));
-    BOOST_CHECK_EQUAL(*((PolyDerived*)i_unique.get()), *((PolyDerived*)o_unique.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerived*>(i_shared.get()), *static_cast<PolyDerived*>(o_shared.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerived*>(i_shared.get()), *static_cast<PolyDerived*>(i_locked.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerived*>(i_locked.get()), *static_cast<PolyDerived*>(o_locked.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerived*>(i_unique.get()), *static_cast<PolyDerived*>(o_unique.get()));
 
-    BOOST_CHECK_EQUAL(*((PolyDerivedLA*)i_sharedLA.get()), *((PolyDerivedLA*)o_sharedLA.get()));
-    BOOST_CHECK_EQUAL(*((PolyDerivedLA*)i_sharedLA2.get()), *((PolyDerivedLA*)o_sharedLA.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerivedLA*>(i_sharedLA.get()), *static_cast<PolyDerivedLA*>(o_sharedLA.get()));
+    BOOST_CHECK_EQUAL(*static_cast<PolyDerivedLA*>(i_sharedLA2.get()), *static_cast<PolyDerivedLA*>(o_sharedLA.get()));
 
     BOOST_CHECK_EQUAL(i_sharedA.get(), i_lockedA.get());
     BOOST_CHECK_EQUAL(*dynamic_cast<PolyDerivedD*>(i_sharedA.get()), *dynamic_cast<PolyDerivedD*>(o_sharedA.get()));

--- a/unittests/portable_binary_archive.cpp
+++ b/unittests/portable_binary_archive.cpp
@@ -72,7 +72,7 @@ inline void swapBytes( T & t )
     BOOST_CHECK_EQUAL(i_int32  , o_int32);               \
     BOOST_CHECK_EQUAL(i_uint64 , o_uint64);              \
     BOOST_CHECK_EQUAL(i_int64  , o_int64);               \
-    if( !std::isnan(i_float) && !std::isnan(o_float) ) BOOST_CHECK_CLOSE(i_float  , o_float,  (float)1e-5); \
+    if( !std::isnan(i_float) && !std::isnan(o_float) ) BOOST_CHECK_CLOSE(i_float  , o_float,  static_cast<float>(1e-5)); \
     if( !std::isnan(i_float) && !std::isnan(o_float) ) BOOST_CHECK_CLOSE(i_double , o_double, 1e-5);
 
 // Last parameter exists to keep everything hidden in options

--- a/unittests/structs_specialized.cpp
+++ b/unittests/structs_specialized.cpp
@@ -441,7 +441,7 @@ void test_structs_specialized()
     BOOST_CHECK(i_ispl.x == o_ispl.x);
     BOOST_CHECK(i_isplv.x == o_isplv.x);
 
-    BOOST_CHECK_EQUAL(((SpecializedMSplitPolymorphic*)i_shared_ispl.get())->x, ((SpecializedMSplitPolymorphic*)o_shared_ispl.get())->x);
+    BOOST_CHECK_EQUAL(static_cast<SpecializedMSplitPolymorphic*>(i_shared_ispl.get())->x, static_cast<SpecializedMSplitPolymorphic*>(o_shared_ispl.get())->x);
 
     BOOST_CHECK(i_isplm.x == o_isplm.x);
     BOOST_CHECK(i_isplvm.x == o_isplvm.x);


### PR DESCRIPTION
Change C style casts to C++ static casts.

This makes the code compile with the -Wold-style-cast warning enabled

Cereal uses fairly clean modern C++ style, but unfortunately a few headers use C style casts meaning they cannot be used without disabling warnings about these casts, using #pragmas or similar.

This shouldn't introduce any functional changes.