### PR TITLE
Doxygen access from extern

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,21 +55,4 @@ endif(Boost_FOUND)
 
 add_subdirectory(sandbox)
 
-find_package(Doxygen)
-if(DOXYGEN_FOUND)
-
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doc/doxygen.in" "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg" @ONLY)
-  add_custom_target(doc
-    COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg"
-    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
-    COMMENT "Generating API documentation with Doxygen" VERBATIM
-    )
-
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scripts/updatedoc.in" "${CMAKE_CURRENT_BINARY_DIR}/updatedoc.sh" @ONLY)
-  add_custom_target(update-doc
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/updatedoc.sh"
-    DEPENDS doc
-    COMMENT "Copying documentation to gh-pages branch" VERBATIM
-    )
-
-endif(DOXYGEN_FOUND)
+add_subdirectory(doc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,18 @@
+find_package(Doxygen)
+if(DOXYGEN_FOUND)
+
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/doxygen.in" "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg" @ONLY)
+  add_custom_target(doc
+    COMMAND ${DOXYGEN_EXECUTABLE} "${CMAKE_CURRENT_BINARY_DIR}/doxygen.cfg"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/.."
+    COMMENT "Generating API documentation with Doxygen" VERBATIM
+    )
+
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/../scripts/updatedoc.in" "${CMAKE_CURRENT_BINARY_DIR}/updatedoc.sh" @ONLY)
+  add_custom_target(update-doc
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/updatedoc.sh"
+    DEPENDS doc
+    COMMENT "Copying documentation to gh-pages branch" VERBATIM
+    )
+
+endif(DOXYGEN_FOUND)

--- a/doc/doxygen.in
+++ b/doc/doxygen.in
@@ -52,7 +52,7 @@ PROJECT_LOGO           =
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = doc
+OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@/
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output
@@ -595,7 +595,7 @@ FILE_VERSION_FILTER    =
 # You can optionally specify a file name after the option, if omitted
 # DoxygenLayout.xml will be used as the name of the layout file.
 
-LAYOUT_FILE            = "@CMAKE_CURRENT_SOURCE_DIR@/doc/DoxygenLayout.xml"
+LAYOUT_FILE            = "@CMAKE_CURRENT_SOURCE_DIR@/DoxygenLayout.xml"
 
 # The CITE_BIB_FILES tag can be used to specify one or more bib files
 # containing the references data. This must be a list of .bib files. The
@@ -668,7 +668,7 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories
 # with spaces.
 
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include @CMAKE_CURRENT_SOURCE_DIR@/doc #include doc
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/../include @CMAKE_CURRENT_SOURCE_DIR@/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is
@@ -701,7 +701,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = external
+EXCLUDE                = @CMAKE_CURRENT_SOURCE_DIR@/../external
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -911,7 +911,7 @@ HTML_HEADER            =
 # each generated HTML page. If it is left blank doxygen will generate a
 # standard footer.
 
-HTML_FOOTER            ="@CMAKE_CURRENT_SOURCE_DIR@/doc/footer.html"
+HTML_FOOTER            ="@CMAKE_CURRENT_SOURCE_DIR@/footer.html"
 
 # The HTML_STYLESHEET tag can be used to specify a user-defined cascading
 # style sheet that is used by each HTML page. It can be used to

--- a/doc/doxygen.in
+++ b/doc/doxygen.in
@@ -1626,7 +1626,7 @@ TAGFILES               =
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.
 
-GENERATE_TAGFILE       =
+GENERATE_TAGFILE       = cereal.doxytags
 
 # If the ALLEXTERNALS tag is set to YES all external classes will be listed
 # in the class index. If set to NO only the inherited external classes


### PR DESCRIPTION
We are using cereal as our serialization library together with our libraries and would like to be able to have our doxygen documentation link to that of cereal.

To do that, a tagfile is needed, and finer control over the output directory is useful.