### PR TITLE
Add is_loading and is_saving values to cereal::{Input,Output}Archive

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -630,7 +630,7 @@ namespace cereal
           from boost, you can check this value within a member or external serialize function
           (i.e., Archive::is_loading::value) to enable behavior specific to loading, until 
           you can transition to split save/load or save_minimal/load_minimal functions */
-.      using is_loading = std::true_type;
+      using is_loading = std::true_type;
 
       //! Indicates this archive is not intended for saving
       /*! This ensures compatibility with boost archive types.  If you are transitioning

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -255,6 +255,20 @@ namespace cereal
           a large project from Boost to cereal.  The preferred interface for cereal is using operator(). */
       //! @{
 
+      //! Indicates this archive is not intended for loading
+      /*! This ensures compatibility with boost archive types.  If you are transitioning
+          from boost, you can check this value within a member or external serialize function
+          (i.e., Archive::is_loading::value) to disable behavior specific to loading, until 
+          you can transition to split save/load or save_minimal/load_minimal functions */
+      using is_loading = std::false_type;
+
+      //! Indicates this archive is intended for saving
+      /*! This ensures compatibility with boost archive types.  If you are transitioning
+          from boost, you can check this value within a member or external serialize function
+          (i.e., Archive::is_saving::value) to enable behavior specific to loading, until 
+          you can transition to split save/load or save_minimal/load_minimal functions */
+      using is_saving = std::true_type;
+
       //! Serializes passed in data
       /*! This is a boost compatability layer and is not the preferred way of using
           cereal.  If you are transitioning from boost, use this until you can
@@ -610,6 +624,20 @@ namespace cereal
           Functionality that mirrors the syntax for Boost.  This is useful if you are transitioning
           a large project from Boost to cereal.  The preferred interface for cereal is using operator(). */
       //! @{
+
+      //! Indicates this archive is intended for loading
+      /*! This ensures compatibility with boost archive types.  If you are transitioning
+          from boost, you can check this value within a member or external serialize function
+          (i.e., Archive::is_loading::value) to enable behavior specific to loading, until 
+          you can transition to split save/load or save_minimal/load_minimal functions */
+.      using is_loading = std::true_type;
+
+      //! Indicates this archive is not intended for saving
+      /*! This ensures compatibility with boost archive types.  If you are transitioning
+          from boost, you can check this value within a member or external serialize function
+          (i.e., Archive::is_saving::value) to disable behavior specific to loading, until 
+          you can transition to split save/load or save_minimal/load_minimal functions */
+      using is_saving = std::false_type;
 
       //! Serializes passed in data
       /*! This is a boost compatability layer and is not the preferred way of using


### PR DESCRIPTION
This provides compatibility for asymmetric serialize routines when transitioning from boost serialization and associated archive types.

See: https://github.com/USCiLab/cereal/issues/360

Example:
```
    template <typename Archive>
    void serialize(Archive &ar, const std::uint32_t version)
    {
        std::int16_t tmp;
        if(Archive::is_loading::value)
        {
            ar & tmp; // load 16 bit type from archive
            m_foo = inflate<std::int32_t>(tmp); // convert to 32 bit for processing
        }
        else
        {
            tmp = deflate<std::in16_t>(m_foo); // convert to 16 bit for storage
            ar & tmp; // save 16 bit
        }
    }
```