### PR TITLE
Using C++11 static_cast instead of C-like casts.

### DIFF
--- a/include/cereal/external/base64.hpp
+++ b/include/cereal/external/base64.hpp
@@ -50,10 +50,10 @@ namespace cereal
       while (in_len--) {
         char_array_3[i++] = *(bytes_to_encode++);
         if (i == 3) {
-          char_array_4[0] = (unsigned char) ((char_array_3[0] & 0xfc) >> 2);
-          char_array_4[1] = (unsigned char) ( ( ( char_array_3[0] & 0x03 ) << 4 ) + ( ( char_array_3[1] & 0xf0 ) >> 4 ) );
-          char_array_4[2] = (unsigned char) ( ( ( char_array_3[1] & 0x0f ) << 2 ) + ( ( char_array_3[2] & 0xc0 ) >> 6 ) );
-          char_array_4[3] = (unsigned char) ( char_array_3[2] & 0x3f );
+          char_array_4[0] = static_cast<unsigned char> (((char_array_3[0] & 0xfc) >> 2));
+          char_array_4[1] = static_cast<unsigned char> ( ( ( ( char_array_3[0] & 0x03 ) << 4 ) + ( ( char_array_3[1] & 0xf0 ) >> 4 ) ) );
+          char_array_4[2] = static_cast<unsigned char> ( ( ( ( char_array_3[1] & 0x0f ) << 2 ) + ( ( char_array_3[2] & 0xc0 ) >> 6 ) ) );
+          char_array_4[3] = static_cast<unsigned char> ( ( char_array_3[2] & 0x3f ) );
 
           for(i = 0; (i <4) ; i++)
             ret += chars[char_array_4[i]];
@@ -95,7 +95,7 @@ namespace cereal
         char_array_4[i++] = encoded_string[in_]; in_++;
         if (i ==4) {
           for (i = 0; i <4; i++)
-            char_array_4[i] = (unsigned char) chars.find( char_array_4[i] );
+            char_array_4[i] = static_cast<unsigned char> ( chars.find( char_array_4[i] ) );
 
           char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
           char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
@@ -112,7 +112,7 @@ namespace cereal
           char_array_4[j] = 0;
 
         for (j = 0; j <4; j++)
-          char_array_4[j] = (unsigned char) chars.find( char_array_4[j] );
+          char_array_4[j] = static_cast<unsigned char> ( chars.find( char_array_4[j] ) );
 
         char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
         char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);


### PR DESCRIPTION
This PR enable the use of the "-Wold-style-cast". Now it is possible to compile source code with strict options in the target project. References #368 .