### PR TITLE
Added withInnerName to set the names of the inner XML tags for lists

### DIFF
--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -199,7 +199,7 @@ namespace cereal
       void startNode()
       {
         // generate a name for this new node
-        const auto nameString = itsNodes.top().getValueName();
+          const auto nameString = itsNodes.top().getValueName();
 
         // allocate strings for all of the data in the XML object
         auto namePtr = itsXML.allocate_string( nameString.data(), nameString.length() + 1 );
@@ -207,7 +207,9 @@ namespace cereal
         // insert into the XML
         auto node = itsXML.allocate_node( rapidxml::node_element, namePtr, nullptr, nameString.size() );
         itsNodes.top().node->append_node( node );
-        itsNodes.emplace( node );
+        const auto innerNameString = itsNodes.top().innerName;
+        itsNodes.emplace(node);
+        itsNodes.top().innerName = innerNameString;
       }
 
       //! Designates the most recently added node as finished
@@ -217,9 +219,10 @@ namespace cereal
       }
 
       //! Sets the name for the next node created with startNode
-      void setNextName( const char * name )
+      void setNextName(const char * name, const char * innerName = nullptr)
       {
-        itsNodes.top().name = name;
+          itsNodes.top().name = name;
+          itsNodes.top().innerName = innerName;
       }
 
       //! Saves some data, encoded as a string, into the current top level node
@@ -297,12 +300,14 @@ namespace cereal
                   const char * nm = nullptr ) :
           node( n ),
           counter( 0 ),
-          name( nm )
+          name( nm ),
+          innerName(nullptr)
         { }
 
         rapidxml::xml_node<> * node; //!< A pointer to this node
         size_t counter;              //!< The counter for naming child nodes
         const char * name;           //!< The name for the next child node
+        const char * innerName;      //!< The name for the inner child node
 
         //! Gets the name for the next child node created from this node
         /*! The name will be automatically generated using the counter if
@@ -313,8 +318,12 @@ namespace cereal
           if( name )
           {
             auto n = name;
-            name = nullptr;
+            name = innerName;
             return {n};
+          }
+          else if (innerName)
+          {
+              return {innerName};
           }
           else
             return "value" + std::to_string( counter++ ) + "\0";
@@ -831,7 +840,7 @@ namespace cereal
   template <class T> inline
   void CEREAL_SAVE_FUNCTION_NAME( XMLOutputArchive & ar, NameValuePair<T> const & t )
   {
-    ar.setNextName( t.name );
+    ar.setNextName( t.name, t.innerName );
     ar( t.value );
   }
 

--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -160,10 +160,12 @@ namespace cereal
                    only pass r-values in cases where this makes sense, such as the result of some
                    size() call.
           @internal */
-      NameValuePair( char const * n, T && v ) : name(n), value(std::forward<T>(v)) {}
+      NameValuePair( char const * n, T && v ) : name(n), value(std::forward<T>(v)), innerName(nullptr) {}
+      NameValuePair<T>& withInnerName(char const* n) { innerName = n; return *this; }
 
       char const * name;
       Type value;
+      char const * innerName;
   };
 
   //! A specialization of make_nvp<> that simply forwards the value for binary archives


### PR DESCRIPTION
See also [this thread](https://github.com/USCiLab/cereal/issues/395).
This PR is about changing the inner node names of XML for lists.
