### PR TITLE
Add option to turn off the size=dynamic attributes of lists

### DIFF
--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -119,13 +119,22 @@ namespace cereal
                             bool outputType = false ) :
             itsPrecision( precision ),
             itsIndent( indent ),
-            itsOutputType( outputType ) { }
+            itsOutputType( outputType ),
+            itsSizeAttributes(true)
+          { }
+
+          Options& NoSizeAttributes()
+          {
+              itsSizeAttributes = false; 
+              return *this;
+          }
 
         private:
           friend class XMLOutputArchive;
           int itsPrecision;
           bool itsIndent;
           bool itsOutputType;
+          bool itsSizeAttributes;
       };
 
       //! Construct, outputting to the provided stream upon destruction
@@ -137,7 +146,8 @@ namespace cereal
         OutputArchive<XMLOutputArchive>(this),
         itsStream(stream),
         itsOutputType( options.itsOutputType ),
-        itsIndent( options.itsIndent )
+        itsIndent( options.itsIndent ),
+        itsSizeAttributes(options.itsSizeAttributes)
       {
         // rapidxml will delete all allocations when xml_document is cleared
         auto node = itsXML.allocate_node( rapidxml::node_declaration );
@@ -289,6 +299,8 @@ namespace cereal
         itsNodes.top().node->append_attribute( itsXML.allocate_attribute( namePtr, valuePtr ) );
       }
 
+      bool hasSizeAttributes() const { return itsSizeAttributes; }
+
     protected:
       //! A struct that contains metadata about a node
       struct NodeInfo
@@ -330,6 +342,7 @@ namespace cereal
       std::ostringstream itsOS;        //!< Used to format strings internally
       bool itsOutputType;              //!< Controls whether type information is printed
       bool itsIndent;                  //!< Controls whether indenting is used
+      bool itsSizeAttributes;          //!< Controls whether lists have a size attribute
   }; // XMLOutputArchive
 
   // ######################################################################
@@ -764,7 +777,10 @@ namespace cereal
   template <class T> inline
   void prologue( XMLOutputArchive & ar, SizeTag<T> const & )
   {
-    ar.appendAttribute( "size", "dynamic" );
+      if (ar.hasSizeAttributes())
+      {
+          ar.appendAttribute("size", "dynamic");
+      }
   }
 
   template <class T> inline


### PR DESCRIPTION
See also [this thread](https://github.com/USCiLab/cereal/issues/395)
This PR is about an option for suppressing the `size="dynamic"` attributes of lists in XML.