### PR TITLE
Develop

### DIFF
--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -62,9 +62,9 @@ namespace cereal
       ~BinaryOutputArchive() CEREAL_NOEXCEPT = default;
 
       //! Writes size bytes of data to the output stream
-      void saveBinary( const void * data, std::size_t size )
+      void saveBinary( const void * data, std::streamsize size )
       {
-        auto const writtenSize = static_cast<std::size_t>( itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ), size ) );
+        auto const writtenSize = itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ), size );
 
         if(writtenSize != size)
           throw Exception("Failed to write " + std::to_string(size) + " bytes to output stream! Wrote " + std::to_string(writtenSize));
@@ -97,9 +97,9 @@ namespace cereal
       ~BinaryInputArchive() CEREAL_NOEXCEPT = default;
 
       //! Reads size bytes of data from the input stream
-      void loadBinary( void * const data, std::size_t size )
+      void loadBinary( void * const data, std::streamsize size )
       {
-        auto const readSize = static_cast<std::size_t>( itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size ) );
+        auto const readSize = itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size );
 
         if(readSize != size)
           throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(readSize));
@@ -148,14 +148,14 @@ namespace cereal
   template <class T> inline
   void CEREAL_SAVE_FUNCTION_NAME(BinaryOutputArchive & ar, BinaryData<T> const & bd)
   {
-    ar.saveBinary( bd.data, static_cast<std::size_t>( bd.size ) );
+    ar.saveBinary( bd.data, static_cast<std::streamsize>( bd.size ) );
   }
 
   //! Loading binary data
   template <class T> inline
   void CEREAL_LOAD_FUNCTION_NAME(BinaryInputArchive & ar, BinaryData<T> & bd)
   {
-    ar.loadBinary(bd.data, static_cast<std::size_t>(bd.size));
+    ar.loadBinary(bd.data, static_cast<std::streamsize>( bd.size ) );
   }
 } // namespace cereal
 

--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -128,19 +128,19 @@ namespace cereal
       ~PortableBinaryOutputArchive() CEREAL_NOEXCEPT = default;
 
       //! Writes size bytes of data to the output stream
-      template <std::size_t DataSize> inline
-      void saveBinary( const void * data, std::size_t size )
+      template <std::streamsize DataSize> inline
+      void saveBinary( const void * data, std::streamsize size )
       {
-        std::size_t writtenSize = 0;
+        std::streamsize writtenSize = 0;
 
         if( itsConvertEndianness )
         {
-          for( std::size_t i = 0; i < size; i += DataSize )
-            for( std::size_t j = 0; j < DataSize; ++j )
-              writtenSize += static_cast<std::size_t>( itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ) + DataSize - j - 1 + i, 1 ) );
+          for( std::streamsize i = 0; i < size; i += DataSize )
+            for( std::streamsize j = 0; j < DataSize; ++j )
+              writtenSize += itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ) + DataSize - j - 1 + i, 1 );
         }
         else
-          writtenSize = static_cast<std::size_t>( itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ), size ) );
+          writtenSize = itsStream.rdbuf()->sputn( reinterpret_cast<const char*>( data ), size );
 
         if(writtenSize != size)
           throw Exception("Failed to write " + std::to_string(size) + " bytes to output stream! Wrote " + std::to_string(writtenSize));
@@ -235,11 +235,11 @@ namespace cereal
       /*! @param data The data to save
           @param size The number of bytes in the data
           @tparam DataSize T The size of the actual type of the data elements being loaded */
-      template <std::size_t DataSize> inline
-      void loadBinary( void * const data, std::size_t size )
+      template <std::streamsize DataSize> inline
+      void loadBinary( void * const data, std::streamsize size )
       {
         // load data
-        auto const readSize = static_cast<std::size_t>( itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size ) );
+        auto const readSize = itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size );
 
         if(readSize != size)
           throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(readSize));
@@ -248,7 +248,7 @@ namespace cereal
         if( itsConvertEndianness )
         {
           std::uint8_t * ptr = reinterpret_cast<std::uint8_t*>( data );
-          for( std::size_t i = 0; i < size; i += DataSize )
+          for( std::streamsize i = 0; i < size; i += DataSize )
             portable_binary_detail::swap_bytes<DataSize>( ptr + i );
         }
       }
@@ -308,7 +308,7 @@ namespace cereal
                    (std::is_floating_point<TT>::value && std::numeric_limits<TT>::is_iec559),
                    "Portable binary only supports IEEE 754 standardized floating point" );
 
-    ar.template saveBinary<sizeof(TT)>( bd.data, static_cast<std::size_t>( bd.size ) );
+    ar.template saveBinary<sizeof(TT)>( bd.data, static_cast<std::streamsize>( bd.size ) );
   }
 
   //! Loading binary data from portable binary
@@ -320,7 +320,7 @@ namespace cereal
                    (std::is_floating_point<TT>::value && std::numeric_limits<TT>::is_iec559),
                    "Portable binary only supports IEEE 754 standardized floating point" );
 
-    ar.template loadBinary<sizeof(TT)>( bd.data, static_cast<std::size_t>( bd.size ) );
+    ar.template loadBinary<sizeof(TT)>( bd.data, static_cast<std::streamsize>( bd.size ) );
   }
 } // namespace cereal
 

--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -110,10 +110,10 @@ namespace cereal
           static Options Default(){ return Options(); }
 
           //! Specify specific options for the XMLOutputArchive
-          /*! @param precision The precision used for floating point numbers
-              @param indent Whether to indent each line of XML
-              @param outputType Whether to output the type of each serialized object as an attribute
-              @param sizeAttributes Whether dynamically sized containers output the size=dynamic attribute */
+          /*! @param precision_ The precision used for floating point numbers
+              @param indent_ Whether to indent each line of XML
+              @param outputType_ Whether to output the type of each serialized object as an attribute
+              @param sizeAttributes_ Whether dynamically sized containers output the size=dynamic attribute */
           explicit Options( int precision_ = std::numeric_limits<double>::max_digits10,
                             bool indent_ = true,
                             bool outputType_ = false,
@@ -210,7 +210,7 @@ namespace cereal
           itsNodes.top().node->append_attribute( itsXML.allocate_attribute( "type", "cereal binary data" ) );
 
         finishNode();
-      };
+      }
 
       //! @}
       /*! @name Internal Functionality
@@ -467,7 +467,7 @@ namespace cereal
         std::memcpy( data, decoded.data(), decoded.size() );
 
         finishNode();
-      };
+      }
 
       //! @}
       /*! @name Internal Functionality

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -145,6 +145,14 @@ namespace cereal
   instantiate_polymorphic_binding( T*, Archive*, BindingTag, adl_tag ); \
   } } /* end namespaces */
 
+  //! Helper macro to omit unused warning
+  #if defined(__GNUC__)
+    // GCC / clang don't want the function
+    #define CEREAL_UNUSED_FUNCTION
+  #else
+    #define CEREAL_UNUSED_FUNCTION static void unused() { (void)version; }
+  #endif
+
   // ######################################################################
   //! Defines a class version for some type
   /*! Versioning information is optional and adds some small amount of
@@ -207,7 +215,7 @@ namespace cereal
              std::type_index(typeid(TYPE)).hash_code(), VERSION_NUMBER );        \
         return VERSION_NUMBER;                                                   \
       }                                                                          \
-      static void unused() { (void)version; }                                    \
+      CEREAL_UNUSED_FUNCTION                                                     \
     }; /* end Version */                                                         \
     const std::uint32_t Version<TYPE>::version =                                 \
       Version<TYPE>::registerVersion();                                          \

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -483,8 +483,7 @@ namespace cereal
       /*! If this is the first time this class has been serialized, we will record its
           version number and serialize that.
 
-          @tparam T The type of the class being serialized
-          @param version The version number associated with it */
+          @tparam T The type of the class being serialized */
       template <class T> inline
       std::uint32_t registerClassVersion()
       {
@@ -875,8 +874,7 @@ namespace cereal
       /*! If this is the first time this class has been serialized, we will record its
           version number and serialize that.
 
-          @tparam T The type of the class being serialized
-          @param version The version number associated with it */
+          @tparam T The type of the class being serialized */
       template <class T> inline
       std::uint32_t loadClassVersion()
       {

--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -256,7 +256,7 @@ namespace cereal
     struct adl_tag;
 
     // used during saving pointers
-    static const int32_t msb_32bit  = 0x80000000;
+    static const uint32_t msb_32bit  = 0x80000000;
     static const int32_t msb2_32bit = 0x40000000;
   }
 

--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -56,6 +56,14 @@
 #include <set>
 #include <stack>
 
+//! Helper macro to omit unused warning
+#if defined(__GNUC__)
+  // GCC / clang don't want the function
+  #define CEREAL_BIND_TO_ARCHIVES_UNUSED_FUNCTION
+#else
+  #define CEREAL_BIND_TO_ARCHIVES_UNUSED_FUNCTION static void unused() { (void)b; }
+#endif
+
 //! Binds a polymorhic type to all registered archives
 /*! This binds a polymorphic type to all compatible registered archives that
     have been registered with CEREAL_REGISTER_ARCHIVE.  This must be called
@@ -67,7 +75,7 @@
     template<>                                                           \
     struct init_binding<__VA_ARGS__> {                                   \
         static bind_to_archives<__VA_ARGS__> const & b;                  \
-        static void unused() { (void)b; }                                \
+        CEREAL_BIND_TO_ARCHIVES_UNUSED_FUNCTION                          \
     };                                                                   \
     bind_to_archives<__VA_ARGS__> const & init_binding<__VA_ARGS__>::b = \
         ::cereal::detail::StaticObject<                                  \

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -95,6 +95,7 @@ namespace cereal
             std::unique_lock<std::mutex> lock;
           #else
           public:
+	    LockGuard(LockGuard const &) = default; // prevents implicit copy ctor warning
             ~LockGuard() CEREAL_NOEXCEPT {} // prevents variable not used
           #endif
         };

--- a/include/cereal/external/base64.hpp
+++ b/include/cereal/external/base64.hpp
@@ -25,6 +25,11 @@
 #ifndef CEREAL_EXTERNAL_BASE64_HPP_
 #define CEREAL_EXTERNAL_BASE64_HPP_
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wconversion"
+#endif
+
 #include <string>
 
 namespace cereal
@@ -123,5 +128,7 @@ namespace cereal
     }
   } // namespace base64
 } // namespace cereal
-
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #endif // CEREAL_EXTERNAL_BASE64_HPP_

--- a/include/cereal/external/rapidxml/rapidxml.hpp
+++ b/include/cereal/external/rapidxml/rapidxml.hpp
@@ -85,7 +85,7 @@ namespace rapidxml
 
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
-        virtual const char *what() const noexcept override
+        virtual const char *what() const CEREAL_NOEXCEPT override
         {
             return m_what;
         }

--- a/include/cereal/external/rapidxml/rapidxml.hpp
+++ b/include/cereal/external/rapidxml/rapidxml.hpp
@@ -85,7 +85,7 @@ namespace rapidxml
 
         //! Gets human readable description of error.
         //! \return Pointer to null terminated description of the error.
-        virtual const char *what() const throw()
+        virtual const char *what() const noexcept override
         {
             return m_what;
         }
@@ -317,7 +317,7 @@ namespace rapidxml
             const Ch *tmp = p;
             while (*tmp)
                 ++tmp;
-            return tmp - p;
+            return static_cast<std::size_t>(tmp - p);
         }
 
         // Compare strings for equality
@@ -387,7 +387,7 @@ namespace rapidxml
     //! If required, you can tweak <code>CEREAL_RAPIDXML_STATIC_POOL_SIZE</code>, <code>CEREAL_RAPIDXML_DYNAMIC_POOL_SIZE</code> and <code>CEREAL_RAPIDXML_ALIGNMENT</code>
     //! to obtain best wasted memory to performance compromise.
     //! To do it, define their values before rapidxml.hpp file is included.
-    //! \param Ch Character type of created nodes.
+    //! \tparam Ch Character type of created nodes.
     template<class Ch = char>
     class memory_pool
     {
@@ -656,7 +656,7 @@ namespace rapidxml
 
     //! Base class for xml_node and xml_attribute implementing common functions:
     //! name(), name_size(), value(), value_size() and parent().
-    //! \param Ch Character type to use
+    //! \tparam Ch Character type to use
     template<class Ch = char>
     class xml_base
     {
@@ -729,7 +729,7 @@ namespace rapidxml
         //! <br><br>
         //! Size of name must be specified separately, because name does not have to be zero terminated.
         //! Use name(const Ch *) function to have the length automatically calculated (string must be zero terminated).
-        //! \param name Name of node to set. Does not have to be zero terminated.
+        //! \param name_ Name of node to set. Does not have to be zero terminated.
         //! \param size Size of name, in characters. This does not include zero terminator, if one is present.
         void name(const Ch *name_, std::size_t size)
         {
@@ -739,7 +739,7 @@ namespace rapidxml
 
         //! Sets name of node to a zero-terminated string.
         //! See also \ref ownership_of_strings and xml_node::name(const Ch *, std::size_t).
-        //! \param name Name of node to set. Must be zero terminated.
+        //! \param name_ Name of node to set. Must be zero terminated.
         void name(const Ch *name_)
         {
             this->name(name_, internal::measure(name_));
@@ -759,7 +759,7 @@ namespace rapidxml
         //! <br><br>
         //! If an element has a child node of type node_data, it will take precedence over element value when printing.
         //! If you want to manipulate data of elements using values, use parser flag rapidxml::parse_no_data_nodes to prevent creation of data nodes by the parser.
-        //! \param value value of node to set. Does not have to be zero terminated.
+        //! \param value_ value of node to set. Does not have to be zero terminated.
         //! \param size Size of value, in characters. This does not include zero terminator, if one is present.
         void value(const Ch *value_, std::size_t size)
         {
@@ -769,7 +769,7 @@ namespace rapidxml
 
         //! Sets value of node to a zero-terminated string.
         //! See also \ref ownership_of_strings and xml_node::value(const Ch *, std::size_t).
-        //! \param value Vame of node to set. Must be zero terminated.
+        //! \param value_ Vame of node to set. Must be zero terminated.
         void value(const Ch *value_)
         {
             this->value(value_, internal::measure(value_));
@@ -806,7 +806,7 @@ namespace rapidxml
     //! Each attribute has name and value strings, which are available through name() and value() functions (inherited from xml_base).
     //! Note that after parse, both name and value of attribute will point to interior of source text used for parsing.
     //! Thus, this text must persist in memory for the lifetime of attribute.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template<class Ch = char>
     class xml_attribute: public xml_base<Ch>
     {
@@ -862,8 +862,8 @@ namespace rapidxml
         }
 
         //! Gets next attribute, optionally matching attribute name.
-        //! \param name Name of attribute to find, or 0 to return next attribute regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
-        //! \param name_size Size of name, in characters, or 0 to have size calculated automatically from string
+        //! \param name_ Name of attribute to find, or 0 to return next attribute regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
+        //! \param name_size_ Size of name, in characters, or 0 to have size calculated automatically from string
         //! \param case_sensitive Should name comparison be case-sensitive; non case-sensitive comparison works properly only for ASCII characters
         //! \return Pointer to found attribute, or 0 if not found.
         xml_attribute<Ch> *next_attribute(const Ch *name_ = 0, std::size_t name_size_ = 0, bool case_sensitive = true) const
@@ -898,7 +898,7 @@ namespace rapidxml
     //! <br><br>
     //! Note that after parse, both name and value of node, if any, will point interior of source text used for parsing.
     //! Thus, this text must persist in the memory for the lifetime of node.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template<class Ch = char>
     class xml_node: public xml_base<Ch>
     {
@@ -910,7 +910,7 @@ namespace rapidxml
 
         //! Constructs an empty node with the specified type.
         //! Consider using memory_pool of appropriate document to allocate nodes manually.
-        //! \param type Type of node to construct.
+        //! \param type_ Type of node to construct.
         xml_node(node_type type_)
             : m_type(type_)
             , m_first_node(0)
@@ -942,8 +942,8 @@ namespace rapidxml
         }
 
         //! Gets first child node, optionally matching node name.
-        //! \param name Name of child to find, or 0 to return first child regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
-        //! \param name_size Size of name, in characters, or 0 to have size calculated automatically from string
+        //! \param name_ Name of child to find, or 0 to return first child regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
+        //! \param name_size_ Size of name, in characters, or 0 to have size calculated automatically from string
         //! \param case_sensitive Should name comparison be case-sensitive; non case-sensitive comparison works properly only for ASCII characters
         //! \return Pointer to found child, or 0 if not found.
         xml_node<Ch> *first_node(const Ch *name_ = 0, std::size_t name_size_ = 0, bool case_sensitive = true) const
@@ -1010,8 +1010,8 @@ namespace rapidxml
         //! Gets next sibling node, optionally matching node name.
         //! Behaviour is undefined if node has no parent.
         //! Use parent() to test if node has a parent.
-        //! \param name Name of sibling to find, or 0 to return next sibling regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
-        //! \param name_size Size of name, in characters, or 0 to have size calculated automatically from string
+        //! \param name_ Name of sibling to find, or 0 to return next sibling regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
+        //! \param name_size_ Size of name, in characters, or 0 to have size calculated automatically from string
         //! \param case_sensitive Should name comparison be case-sensitive; non case-sensitive comparison works properly only for ASCII characters
         //! \return Pointer to found sibling, or 0 if not found.
         xml_node<Ch> *next_sibling(const Ch *name_ = 0, std::size_t name_size_ = 0, bool case_sensitive = true) const
@@ -1031,8 +1031,8 @@ namespace rapidxml
         }
 
         //! Gets first attribute of node, optionally matching attribute name.
-        //! \param name Name of attribute to find, or 0 to return first attribute regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
-        //! \param name_size Size of name, in characters, or 0 to have size calculated automatically from string
+        //! \param name_ Name of attribute to find, or 0 to return first attribute regardless of its name; this string doesn't have to be zero-terminated if name_size is non-zero
+        //! \param name_size_ Size of name, in characters, or 0 to have size calculated automatically from string
         //! \param case_sensitive Should name comparison be case-sensitive; non case-sensitive comparison works properly only for ASCII characters
         //! \return Pointer to found attribute, or 0 if not found.
         xml_attribute<Ch> *first_attribute(const Ch *name_ = 0, std::size_t name_size_ = 0, bool case_sensitive = true) const
@@ -1074,7 +1074,7 @@ namespace rapidxml
         // Node modification
 
         //! Sets type of node.
-        //! \param type Type of node to set.
+        //! \param type_ Type of node to set.
         void type(node_type type_)
         {
             m_type = type_;
@@ -1366,7 +1366,7 @@ namespace rapidxml
     //! parse() function allocates memory for nodes and attributes by using functions of xml_document,
     //! which are inherited from memory_pool.
     //! To access root node of the document, use the document itself, as if it was an xml_node.
-    //! \param Ch Character type to use.
+    //! \tparam Ch Character type to use.
     template<class Ch = char>
     class xml_document: public xml_node<Ch>, public memory_pool<Ch>
     {
@@ -1527,7 +1527,7 @@ namespace rapidxml
             {
                 // Insert 8-bit ASCII character
                 // Todo: possibly verify that code is less than 256 and use replacement char otherwise?
-                text[0] = static_cast<unsigned char>(code);
+                text[0] = static_cast<Ch>(code);
                 text += 1;
             }
             else
@@ -1535,28 +1535,28 @@ namespace rapidxml
                 // Insert UTF8 sequence
                 if (code < 0x80)    // 1 byte sequence
                 {
-	                text[0] = static_cast<unsigned char>(code);
+	                text[0] = static_cast<Ch>(code);
                     text += 1;
                 }
                 else if (code < 0x800)  // 2 byte sequence
                 {
-	                text[1] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[0] = static_cast<unsigned char>(code | 0xC0);
+	                text[1] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[0] = static_cast<Ch>(code | 0xC0);
                     text += 2;
                 }
 	            else if (code < 0x10000)    // 3 byte sequence
                 {
-	                text[2] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[1] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[0] = static_cast<unsigned char>(code | 0xE0);
+	                text[2] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[1] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[0] = static_cast<Ch>(code | 0xE0);
                     text += 3;
                 }
 	            else if (code < 0x110000)   // 4 byte sequence
                 {
-	                text[3] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[2] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[1] = static_cast<unsigned char>((code | 0x80) & 0xBF); code >>= 6;
-	                text[0] = static_cast<unsigned char>(code | 0xF0);
+	                text[3] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[2] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[1] = static_cast<Ch>((code | 0x80) & 0xBF); code >>= 6;
+	                text[0] = static_cast<Ch>(code | 0xF0);
                     text += 4;
                 }
                 else    // Invalid, only codes up to 0x10FFFF are allowed in Unicode
@@ -1812,7 +1812,7 @@ namespace rapidxml
 
             // Create comment node
             xml_node<Ch> *comment = this->allocate_node(node_comment);
-            comment->value(value_, text - value_);
+            comment->value(value_, static_cast<std::size_t>(text - value_));
 
             // Place zero terminator after comment value
             if (!(Flags & parse_no_string_terminators))
@@ -1871,7 +1871,7 @@ namespace rapidxml
             {
                 // Create a new doctype node
                 xml_node<Ch> *doctype = this->allocate_node(node_doctype);
-                doctype->value(value_, text - value_);
+                doctype->value(value_, static_cast<std::size_t>(text - value_));
 
                 // Place zero terminator after value
                 if (!(Flags & parse_no_string_terminators))
@@ -1903,7 +1903,7 @@ namespace rapidxml
                 skip<node_name_pred, Flags>(text);
                 if (text == name_)
                     CEREAL_RAPIDXML_PARSE_ERROR("expected PI target", text);
-                pi->name(name_, text - name_);
+                pi->name(name_, static_cast<std::size_t>(text - name_));
 
                 // Skip whitespace between pi target and pi
                 skip<whitespace_pred, Flags>(text);
@@ -1920,7 +1920,7 @@ namespace rapidxml
                 }
 
                 // Set pi value (verbatim, no entity expansion or whitespace normalization)
-                pi->value(value_, text - value_);
+                pi->value(value_, static_cast<std::size_t>(text - value_));
 
                 // Place zero terminator after name and value
                 if (!(Flags & parse_no_string_terminators))
@@ -1987,14 +1987,14 @@ namespace rapidxml
             if (!(Flags & parse_no_data_nodes))
             {
                 xml_node<Ch> *data = this->allocate_node(node_data);
-                data->value(value_, end - value_);
+                data->value(value_, static_cast<std::size_t>(end - value_));
                 node->append_node(data);
             }
 
             // Add data to parent node if no data exists yet
             if (!(Flags & parse_no_element_values))
                 if (*node->value() == Ch('\0'))
-                    node->value(value_, end - value_);
+                    node->value(value_, static_cast<std::size_t>(end - value_));
 
             // Place zero terminator after value
             if (!(Flags & parse_no_string_terminators))
@@ -2037,7 +2037,7 @@ namespace rapidxml
 
             // Create new cdata node
             xml_node<Ch> *cdata = this->allocate_node(node_cdata);
-            cdata->value(value_, text - value_);
+            cdata->value(value_, static_cast<std::size_t>(text - value_));
 
             // Place zero terminator after value
             if (!(Flags & parse_no_string_terminators))
@@ -2059,7 +2059,7 @@ namespace rapidxml
             skip<node_name_pred, Flags>(text);
             if (text == name_)
                 CEREAL_RAPIDXML_PARSE_ERROR("expected element name", text);
-            element->name(name_, text - name_);
+            element->name(name_, static_cast<std::size_t>(text - name_));
 
             // Skip whitespace between element name and attributes or >
             skip<whitespace_pred, Flags>(text);
@@ -2216,7 +2216,7 @@ namespace rapidxml
                             // Skip and validate closing tag name
                             Ch *closing_name = text;
                             skip<node_name_pred, Flags>(text);
-                            if (!internal::compare(node->name(), node->name_size(), closing_name, text - closing_name, true))
+                            if (!internal::compare(node->name(), node->name_size(), closing_name, static_cast<std::size_t>(text - closing_name), true))
                                 CEREAL_RAPIDXML_PARSE_ERROR("invalid closing tag name", text);
                         }
                         else
@@ -2232,7 +2232,7 @@ namespace rapidxml
 
                         if (contents_end && contents_end != contents_start)
                         {
-                            node->value(contents_start, contents_end - contents_start);
+                            node->value(contents_start, static_cast<std::size_t>(contents_end - contents_start));
                             node->value()[node->value_size()] = Ch('\0');
                         }
                         return;     // Node closed, finished parsing contents
@@ -2275,7 +2275,7 @@ namespace rapidxml
 
                 // Create new attribute
                 xml_attribute<Ch> *attribute = this->allocate_attribute();
-                attribute->name(name_, text - name_);
+                attribute->name(name_, static_cast<std::size_t>(text - name_));
                 node->append_attribute(attribute);
 
                 // Skip whitespace after attribute name
@@ -2308,7 +2308,7 @@ namespace rapidxml
                     end = skip_and_expand_character_refs<attribute_value_pred<Ch('"')>, attribute_value_pure_pred<Ch('"')>, AttFlags>(text, false);
 
                 // Set attribute value
-                attribute->value(value_, end - value_);
+                attribute->value(value_, static_cast<std::size_t>(end - value_));
 
                 // Make sure that end quote is present
                 if (*text != quote)

--- a/include/cereal/external/rapidxml/rapidxml_print.hpp
+++ b/include/cereal/external/rapidxml/rapidxml_print.hpp
@@ -363,10 +363,12 @@ namespace rapidxml
                 out = print_pi_node(out, node, flags, indent);
                 break;
 
+#ifndef __GNUC__
                 // Unknown
             default:
                 assert(0);
                 break;
+#endif
             }
 
             // If indenting not disabled, add line break after node

--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -54,6 +54,7 @@ namespace cereal
       PtrWrapper(T && p) : ptr(std::forward<T>(p)) {}
       T & ptr;
 
+      PtrWrapper( PtrWrapper const & ) = default;
       PtrWrapper & operator=( PtrWrapper const & ) = delete;
     };
 

--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -284,7 +284,7 @@ namespace cereal
 
     if( id & detail::msb_32bit )
     {
-      auto  ptr = std::const_pointer_cast<std::decay_t<T>>(wrapper.ptr);
+      auto ptr = std::const_pointer_cast<typename std::decay<T>::type>(wrapper.ptr);
       // Storage type for the pointer - since we can't default construct this type,
       // we'll allocate it using std::aligned_storage and use a custom deleter
       using ST = typename std::aligned_storage<sizeof(T), CEREAL_ALIGNOF(T)>::type;
@@ -316,7 +316,7 @@ namespace cereal
       wrapper.ptr = ptr;
     }
     else
-      wrapper.ptr = std::static_pointer_cast<std::decay_t<T>>(ar.getSharedPointer(id));
+      wrapper.ptr = std::static_pointer_cast<typename std::decay<T>::type>(ar.getSharedPointer(id));
   }
 
   //! Loading std::shared_ptr, case when no user load and construct (wrapper implementation)
@@ -331,8 +331,8 @@ namespace cereal
 
     if( id & detail::msb_32bit )
     {
-      auto  ptr = std::const_pointer_cast<std::decay_t<T>>(wrapper.ptr);
-      ptr.reset( detail::Construct<std::decay_t<T>, Archive>::load_andor_construct() );
+      auto ptr = std::const_pointer_cast<typename std::decay<T>::type>(wrapper.ptr);
+      ptr.reset( detail::Construct<typename std::decay<T>::type, Archive>::load_andor_construct() );
       ar.registerSharedPointer( id, ptr );
       ar( CEREAL_NVP_("data", *ptr) );
       wrapper.ptr = ptr;

--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -38,7 +38,7 @@ namespace cereal
   namespace tuple_detail
   {
     //! Creates a c string from a sequence of characters
-    /*! The c string created will alwas be prefixed by "tuple_element"
+    /*! The c string created will always be prefixed by "tuple_element"
         Based on code from: http://stackoverflow/a/20973438/710791
         @internal */
     template<char...Cs>
@@ -63,7 +63,7 @@ namespace cereal
     template <size_t Q, size_t R, char ... C>
     struct to_string_impl
     {
-      using type = typename to_string_impl<Q/10, Q%10, R+'0', C...>::type;
+      using type = typename to_string_impl<Q/10, Q%10, static_cast<char>(R+std::size_t{'0'}), C...>::type;
     };
 
     //! Base case with no quotient
@@ -71,7 +71,7 @@ namespace cereal
     template <size_t R, char ... C>
     struct to_string_impl<0, R, C...>
     {
-      using type = char_seq_to_c_str<R+'0', C...>;
+      using type = char_seq_to_c_str<static_cast<char>(R+std::size_t{'0'}), C...>;
     };
 
     //! Generates a c string for a given index of a tuple

--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -84,7 +84,7 @@ namespace cereal
     struct tuple_element_name
     {
       using type = typename to_string_impl<T/10, T%10>::type;
-      static const typename type::arr_type c_str(){ return type::str; };
+      static const typename type::arr_type c_str(){ return type::str; }
     };
 
     // unwinds a tuple to save it

--- a/include/cereal/types/vector.hpp
+++ b/include/cereal/types/vector.hpp
@@ -60,8 +60,8 @@ namespace cereal
 
   //! Serialization for non-arithmetic vector types
   template <class Archive, class T, class A> inline
-  typename std::enable_if<!traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+  typename std::enable_if<(!traits::is_output_serializable<BinaryData<T>, Archive>::value
+                          || !std::is_arithmetic<T>::value) && !std::is_same<T, bool>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::vector<T, A> const & vector )
   {
     ar( make_size_tag( static_cast<size_type>(vector.size()) ) ); // number of elements
@@ -71,8 +71,8 @@ namespace cereal
 
   //! Serialization for non-arithmetic vector types
   template <class Archive, class T, class A> inline
-  typename std::enable_if<!traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+  typename std::enable_if<(!traits::is_input_serializable<BinaryData<T>, Archive>::value
+                          || !std::is_arithmetic<T>::value) && !std::is_same<T, bool>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::vector<T, A> & vector )
   {
     size_type size;
@@ -88,7 +88,7 @@ namespace cereal
   void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::vector<bool, A> const & vector )
   {
     ar( make_size_tag( static_cast<size_type>(vector.size()) ) ); // number of elements
-    for(auto && v : vector)
+    for(const auto v : vector)
       ar( static_cast<bool>(v) );
   }
 
@@ -100,7 +100,7 @@ namespace cereal
     ar( make_size_tag( size ) );
 
     vector.resize( static_cast<std::size_t>( size ) );
-    for(auto && v : vector)
+    for(auto v : vector)
     {
       bool b;
       ar( b );

--- a/unittests/memory.hpp
+++ b/unittests/memory.hpp
@@ -45,6 +45,7 @@ void test_memory()
     std::shared_ptr<int> o_nullptr2;
 
     std::unique_ptr<int> o_zptr1(new int(random_value<int>(gen)));
+    std::unique_ptr<const int> o_zptr2(new int(random_value<int>(gen)));
     std::unique_ptr<int> o_nullptr3;
 
     std::ostringstream os;
@@ -55,7 +56,7 @@ void test_memory()
       oar( o_yptr1, o_yptr2 );
       oar( o_nullptr1, o_nullptr2 );
 
-      oar( o_zptr1 );
+      oar( o_zptr1, o_zptr2 );
       oar( o_nullptr3 );
     }
 
@@ -68,6 +69,7 @@ void test_memory()
     std::shared_ptr<int> i_nullptr2;
 
     std::unique_ptr<int> i_zptr1;
+    std::unique_ptr<const int> i_zptr2;
     std::unique_ptr<int> i_nullptr3;
 
     std::istringstream is(os.str());
@@ -78,7 +80,7 @@ void test_memory()
       iar( i_yptr1, i_yptr2 );
       iar( i_nullptr1, i_nullptr2 );
 
-      iar( i_zptr1 );
+      iar( i_zptr1, i_zptr2 );
       iar( i_nullptr3 );
     }
 
@@ -100,6 +102,7 @@ void test_memory()
     CHECK_EQ(*i_xptr3, *o_xptr3);
 
     CHECK_EQ(*i_zptr1, *o_zptr1);
+    CHECK_EQ(*i_zptr2, *o_zptr2);
     CHECK_UNARY_FALSE(i_nullptr3);
   }
 }

--- a/unittests/memory.hpp
+++ b/unittests/memory.hpp
@@ -44,6 +44,9 @@ void test_memory()
     std::shared_ptr<int> o_nullptr1;
     std::shared_ptr<int> o_nullptr2;
 
+    std::unique_ptr<int> o_zptr1(new int(random_value<int>(gen)));
+    std::unique_ptr<int> o_nullptr3;
+
     std::ostringstream os;
     {
       OArchive oar(os);
@@ -51,6 +54,9 @@ void test_memory()
       oar( o_xptr1, o_xptr2, o_xptr3 );
       oar( o_yptr1, o_yptr2 );
       oar( o_nullptr1, o_nullptr2 );
+
+      oar( o_zptr1 );
+      oar( o_nullptr3 );
     }
 
     std::shared_ptr<int> i_xptr1;
@@ -61,13 +67,19 @@ void test_memory()
     std::shared_ptr<int> i_nullptr1;
     std::shared_ptr<int> i_nullptr2;
 
+    std::unique_ptr<int> i_zptr1;
+    std::unique_ptr<int> i_nullptr3;
+
     std::istringstream is(os.str());
     {
       IArchive iar(is);
 
       iar( i_xptr1, i_xptr2, i_xptr3 );
-      iar( i_yptr1, i_yptr2);
+      iar( i_yptr1, i_yptr2 );
       iar( i_nullptr1, i_nullptr2 );
+
+      iar( i_zptr1 );
+      iar( i_nullptr3 );
     }
 
     CHECK_EQ(o_xptr1.get(), o_xptr2.get());
@@ -86,6 +98,9 @@ void test_memory()
     CHECK_EQ(*i_xptr1, *o_xptr1);
     CHECK_EQ(*i_xptr2, *o_xptr2);
     CHECK_EQ(*i_xptr3, *o_xptr3);
+
+    CHECK_EQ(*i_zptr1, *o_zptr1);
+    CHECK_UNARY_FALSE(i_nullptr3);
   }
 }
 

--- a/unittests/memory.hpp
+++ b/unittests/memory.hpp
@@ -38,6 +38,7 @@ void test_memory()
   {
     std::shared_ptr<int> o_xptr1 = std::make_shared<int>(random_value<int>(gen));
     std::shared_ptr<int> o_xptr2 = o_xptr1;
+    std::shared_ptr<const int> o_xptr3 = o_xptr1;
     std::shared_ptr<int> o_yptr1 = std::make_shared<int>(random_value<int>(gen));
     std::shared_ptr<int> o_yptr2 = o_yptr1;
     std::shared_ptr<int> o_nullptr1;
@@ -47,13 +48,14 @@ void test_memory()
     {
       OArchive oar(os);
 
-      oar( o_xptr1, o_xptr2 );
+      oar( o_xptr1, o_xptr2, o_xptr3 );
       oar( o_yptr1, o_yptr2 );
       oar( o_nullptr1, o_nullptr2 );
     }
 
     std::shared_ptr<int> i_xptr1;
     std::shared_ptr<int> i_xptr2;
+    std::shared_ptr<const int> i_xptr3;
     std::shared_ptr<int> i_yptr1;
     std::shared_ptr<int> i_yptr2;
     std::shared_ptr<int> i_nullptr1;
@@ -63,20 +65,27 @@ void test_memory()
     {
       IArchive iar(is);
 
-      iar( i_xptr1, i_xptr2);
+      iar( i_xptr1, i_xptr2, i_xptr3 );
       iar( i_yptr1, i_yptr2);
       iar( i_nullptr1, i_nullptr2 );
     }
 
     CHECK_EQ(o_xptr1.get(), o_xptr2.get());
+    CHECK_EQ(o_xptr1.get(), o_xptr3.get());
     CHECK_EQ(i_xptr1.get(), i_xptr2.get());
+    CHECK_EQ(i_xptr1.get(), i_xptr3.get());
     CHECK_EQ(*i_xptr1,      *i_xptr2);
+    CHECK_EQ(*i_xptr1,      *i_xptr3);
 
     CHECK_EQ(o_yptr1.get(), o_yptr2.get());
     CHECK_EQ(i_yptr1.get(), i_yptr2.get());
     CHECK_EQ(*i_yptr1,      *i_yptr2);
     CHECK_UNARY_FALSE(i_nullptr1);
     CHECK_UNARY_FALSE(i_nullptr2);
+
+    CHECK_EQ(*i_xptr1, *o_xptr1);
+    CHECK_EQ(*i_xptr2, *o_xptr2);
+    CHECK_EQ(*i_xptr3, *o_xptr3);
   }
 }
 
@@ -88,7 +97,7 @@ class TestClass
 
   private:
     friend class cereal::access;
-    TestClass() { };
+    TestClass() = default;
 
     template<class Archive>
       void serialize(Archive & ar) { ar(x); }


### PR DESCRIPTION
The second commit fixes many compiler warnings that GCC and Clang give when compiling with `-Wconversion` and `-Wdocumentation`.