### PR TITLE
Remove conflicting defines for Windows.h

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -273,7 +273,7 @@ namespace cereal
               return {path.size(), path};
             }
             else
-              return {std::numeric_limits<size_t>::max(), {}};
+              return {(std::numeric_limits<size_t>::max)(), {}};
           };
 
           std::stack<std::type_index>         parentStack;      // Holds the parent nodes to be processed


### PR DESCRIPTION
  * Some Windows SDK installations (like mine) may define `max' in
    `Windows.h', causing `std::numeric_limits::max()' cease to work.

    Details: https://stackoverflow.com/q/27442885/275221

Signed-off-by: Soroush Rabiei <soroush.rabiei@gmail.com>