### PR TITLE
fix CEREAL_*_DYNAMIC_INIT

### DIFF
--- a/include/cereal/types/polymorphic.hpp
+++ b/include/cereal/types/polymorphic.hpp
@@ -165,17 +165,19 @@
     See CEREAL_REGISTER_DYNAMIC_INIT for detailed explanation
     of how this macro should be used.  The name used should
     match that for CEREAL_REGISTER_DYNAMIC_INIT. */
-#define CEREAL_FORCE_DYNAMIC_INIT(LibName)              \
-  namespace cereal {                                    \
-  namespace detail {                                    \
-    void dynamic_init_dummy_##LibName();                \
-  } /* end detail */                                    \
-  namespace {                                           \
-    void dynamic_init_##LibName()                       \
-    {                                                   \
-      ::cereal::detail::dynamic_init_dummy_##LibName(); \
-    }                                                   \
-  } } /* end namespaces */
+#define CEREAL_FORCE_DYNAMIC_INIT(LibName)                \
+  namespace cereal {                                      \
+  namespace detail {                                      \
+    void dynamic_init_dummy_##LibName();                  \
+  } /* end detail */                                      \
+  } /* end cereal */                                      \
+  namespace {                                             \
+    struct dynamic_init_##LibName {                       \
+      dynamic_init_##LibName() {                          \
+        ::cereal::detail::dynamic_init_dummy_##LibName(); \
+      }                                                   \
+    } dynamic_init_instance_##LibName;                    \
+  } /* end anonymous namespace */
 
 namespace cereal
 {


### PR DESCRIPTION
The `CEREAL_FORCE_DYNAMIC_INIT` macro does not work in our code base with higher optimization.  It does work in the debug build.  The compiler also warns about unused functions.

It seems they are just optimized away.  I'm not sure whether that's legal by the compiler.

I changed the macro to use a static object local to the translation unit that calls the function in its constructor.  This works for us now.