### PR TITLE
Fix for #416, Implicit falltrough warning on GCC7.1 (Re-sending)

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -68,7 +68,7 @@ namespace cereal
 #include <vector>
 #include <string>
 
-#if defined(__clang__) or (defined(__GNUC__) and __GNUC__ >= 7)
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7)
 CEREAL_RAPIDJSON_DIAG_PUSH
 CEREAL_RAPIDJSON_DIAG_OFF(implicit-fallthrough)
 #endif
@@ -1014,7 +1014,7 @@ CEREAL_REGISTER_ARCHIVE(cereal::JSONOutputArchive)
 // tie input and output archives together
 CEREAL_SETUP_ARCHIVE_TRAITS(cereal::JSONInputArchive, cereal::JSONOutputArchive)
 
-#if defined(__clang__) or (defined(__GNUC__) and __GNUC__ >= 7)
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 7)
 CEREAL_RAPIDJSON_DIAG_POP
 #endif
 

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -68,6 +68,11 @@ namespace cereal
 #include <vector>
 #include <string>
 
+#if defined(__clang__) or (defined(__GNUC__) and __GNUC__ >= 7)
+CEREAL_RAPIDJSON_DIAG_PUSH
+CEREAL_RAPIDJSON_DIAG_OFF(implicit-fallthrough)
+#endif
+
 namespace cereal
 {
   // ######################################################################
@@ -1008,5 +1013,9 @@ CEREAL_REGISTER_ARCHIVE(cereal::JSONOutputArchive)
 
 // tie input and output archives together
 CEREAL_SETUP_ARCHIVE_TRAITS(cereal::JSONInputArchive, cereal::JSONOutputArchive)
+
+#if defined(__clang__) or (defined(__GNUC__) and __GNUC__ >= 7)
+CEREAL_RAPIDJSON_DIAG_POP
+#endif
 
 #endif // CEREAL_ARCHIVES_JSON_HPP_

--- a/include/cereal/external/rapidjson/internal/regex.h
+++ b/include/cereal/external/rapidjson/internal/regex.h
@@ -29,6 +29,9 @@ CEREAL_RAPIDJSON_DIAG_OFF(implicit-fallthrough)
 #ifdef __GNUC__
 CEREAL_RAPIDJSON_DIAG_PUSH
 CEREAL_RAPIDJSON_DIAG_OFF(effc++)
+#if __GNUC__ >= 7
+    CEREAL_RAPIDJSON_DIAG_OFF(implicit-fallthrough)
+#endif
 #endif
 
 #ifdef _MSC_VER
@@ -691,6 +694,10 @@ typedef GenericRegex<UTF8<> > Regex;
 CEREAL_RAPIDJSON_NAMESPACE_END
 
 #ifdef __clang__
+CEREAL_RAPIDJSON_DIAG_POP
+#endif
+
+#ifdef __GNUC__
 CEREAL_RAPIDJSON_DIAG_POP
 #endif
 


### PR DESCRIPTION
Although, I've opened a PR in #427, it got closed and says that it is merged. However, it also shows that no files are changed and I cannot find the commit message that shows it got merged. Thus, I am re-sending this pull request, with the fix that I've mentioned in that PR.

This one also fixes the build problem submitted in PR #431. 