### PR TITLE
Add serialization support for C++17 std::optional and std::variant

### DIFF
--- a/include/cereal/types/optional.cpp
+++ b/include/cereal/types/optional.cpp
@@ -1,0 +1,109 @@
+/*
+  Copyright (c) 2017, Juan Pedro Bolivar Puente
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES AND SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "common.hpp"
+
+#if __cplusplus >= 201703L
+
+#include <cereal/types/optional.hpp>
+
+template <class IArchive, class OArchive> inline
+void test_std_optional()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  std::optional<int> o_bv1 = random_value<int>(gen);
+  std::optional<double> o_bv2 = random_value<double>(gen);
+  std::optional<std::string> o_bv3 = random_basic_string<char>(gen);
+  std::optional<int> o_bv4 = std::nullopt;
+  std::optional<double> o_bv5 = std::nullopt;
+  std::optional<std::string> o_bv6 = std::nullopt;
+
+  std::ostringstream os;
+  {
+    OArchive oar(os);
+
+    oar(o_bv1);
+    oar(o_bv2);
+    oar(o_bv3);
+    oar(o_bv4);
+    oar(o_bv5);
+    oar(o_bv6);
+  }
+
+  decltype(o_bv1) i_bv1;
+  decltype(o_bv2) i_bv2;
+  decltype(o_bv3) i_bv3;
+  decltype(o_bv4) i_bv4;
+  decltype(o_bv5) i_bv5;
+  decltype(o_bv6) i_bv6;
+
+  std::istringstream is(os.str());
+  {
+    IArchive iar(is);
+
+    iar(i_bv1);
+    iar(i_bv2);
+    iar(i_bv3);
+  }
+
+  CHECK_EQ( *i_bv1, std::get<int>(o_bv1) );
+  CHECK_EQ( *i_bv2, doctest::Approx(std::get<double>(o_bv2)).epsilon(1e-5) );
+  CHECK_EQ( *i_bv3, std::get<std::string>(o_bv3) );
+  CHECK( !i_bv4 );
+  CHECK( !i_bv5 );
+  CHECK( !i_bv6 );
+}
+
+TEST_SUITE("std_optional");
+
+TEST_CASE("binary_std_optional")
+{
+  test_std_optional<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+TEST_CASE("portable_binary_std_optional")
+{
+  test_std_optional<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
+TEST_CASE("xml_std_optional")
+{
+  test_std_optional<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+TEST_CASE("json_std_optional")
+{
+  test_std_optional<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+TEST_SUITE_END();
+
+#endif // is c++17

--- a/include/cereal/types/optional.hpp
+++ b/include/cereal/types/optional.hpp
@@ -1,0 +1,64 @@
+/*! \file optional.hpp
+    \brief Support for std::optional
+    \ingroup OtherTypes */
+/*
+  Copyright (c) 2017, Juan Pedro Bolivar Puente
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES OR SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef CEREAL_TYPES_STD_OPTIONAL_
+#define CEREAL_TYPES_STD_OPTIONAL_
+
+#include <cereal/cereal.hpp>
+#include <optional>
+
+namespace cereal {
+  template <class Archive, typename T> inline
+  void CEREAL_SAVE_FUNCTION_NAME(Archive& ar, const std::optional<T>& optional)
+  {
+    if(optional) {
+      ar(CEREAL_NVP_("nullopt", true));
+    } else {
+      ar(CEREAL_NVP_("nullopt", false),
+         CEREAL_NVP_("value", *optional));
+    }
+  }
+
+  template <class Archive, typename T> inline
+  void CEREAL_LOAD_FUNCTION_NAME(Archive& ar, std::optional<T>& optional)
+  {
+    bool nullopt;
+    ar(CEREAL_NVP_("nullopt", nullopt));
+
+    if (nullopt) {
+      optional = std::nullopt;
+    } else {
+      T value;
+      ar(CEREAL_NVP_("value", value));
+      optional = std::move(value);
+    }
+  }
+} // namespace cereal
+
+#endif // CEREAL_TYPES_STD_OPTIONAL_

--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -1,0 +1,104 @@
+/*! \file variant.hpp
+    \brief Support for std::variant
+    \ingroup OtherTypes */
+/*
+  Copyright (c) 2014, 2017, Randolph Voorhies, Shane Grant, Juan Pedro
+  Bolivar Puente. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES OR SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef CEREAL_TYPES_STD_VARIANT_HPP_
+#define CEREAL_TYPES_STD_VARIANT_HPP_
+
+#include "cereal/cereal.hpp"
+#include <variant>
+
+namespace cereal
+{
+  namespace variant_detail
+  {
+    //! @internal
+    template <class Archive>
+    struct variant_save_visitor
+    {
+      variant_save_visitor(Archive & ar_) : ar(ar_) {}
+
+      template<class T>
+        void operator()(T const & value) const
+        {
+          ar( CEREAL_NVP_("data", value) );
+        }
+
+      Archive & ar;
+    };
+
+    //! @internal
+    template<int N, class Variant, class ... Args, class Archive>
+    typename std::enable_if<N == std::variant_size_v<Variant>, void>::type
+    load_variant(Archive & /*ar*/, int /*target*/, Variant & /*variant*/)
+    {
+      throw ::cereal::Exception("Error traversing variant during load");
+    }
+    //! @internal
+    template<int N, class Variant, class H, class ... T, class Archive>
+    typename std::enable_if<N < std::variant_size_v<Variant>, void>::type
+    load_variant(Archive & ar, int target, Variant & variant)
+    {
+      if(N == target)
+      {
+        H value;
+        ar( CEREAL_NVP_("data", value) );
+        variant = std::move(value);
+      }
+      else
+        load_variant<N+1, Variant, T...>(ar, target, variant);
+    }
+
+  } // namespace variant_detail
+
+  //! Saving for std::variant
+  template <class Archive, typename VariantType1, typename... VariantTypes> inline
+  void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::variant<VariantType1, VariantTypes...> const & variant )
+  {
+    auto index = variant.index();
+    ar( CEREAL_NVP_("index", index) );
+    variant_detail::variant_save_visitor<Archive> visitor(ar);
+    std::visit(visitor, variant);
+  }
+
+  //! Loading for std::variant
+  template <class Archive, typename... VariantTypes> inline
+  void CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::variant<VariantTypes...> & variant )
+  {
+    using variant_t = typename std::variant<VariantTypes...>;
+
+    decltype(variant.index()) index;
+    ar( CEREAL_NVP_("index", index) );
+    if(index >= std::variant_size_v<variant_t>)
+      throw Exception("Invalid 'index' selector when deserializing std::variant");
+
+    variant_detail::load_variant<0, variant_t, VariantTypes...>(ar, index, variant);
+  }
+} // namespace cereal
+
+#endif // CEREAL_TYPES_STD_VARIANT_HPP_

--- a/unittests/variant.cpp
+++ b/unittests/variant.cpp
@@ -1,0 +1,97 @@
+/*
+  Copyright (c) 2015, Kyle Fleming, Juan Pedro Bolivar Puente
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of cereal nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL RANDOLPH VOORHIES AND SHANE GRANT BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+
+#include "common.hpp"
+
+#if __cplusplus >= 201703L
+
+#include <cereal/types/variant.hpp>
+
+template <class IArchive, class OArchive> inline
+void test_std_variant()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  std::variant<int, double, std::string> o_bv1 = random_value<int>(gen);
+  std::variant<int, double, std::string> o_bv2 = random_value<double>(gen);
+  std::variant<int, double, std::string> o_bv3 = random_basic_string<char>(gen);
+
+  std::ostringstream os;
+  {
+    OArchive oar(os);
+
+    oar(o_bv1);
+    oar(o_bv2);
+    oar(o_bv3);
+  }
+
+  decltype(o_bv1) i_bv1;
+  decltype(o_bv2) i_bv2;
+  decltype(o_bv3) i_bv3;
+
+  std::istringstream is(os.str());
+  {
+    IArchive iar(is);
+
+    iar(i_bv1);
+    iar(i_bv2);
+    iar(i_bv3);
+  }
+
+  CHECK_EQ( std::get<int>(i_bv1), std::get<int>(o_bv1) );
+  CHECK_EQ( std::get<double>(i_bv2), doctest::Approx(std::get<double>(o_bv2)).epsilon(1e-5) );
+  CHECK_EQ( std::get<std::string>(i_bv3), std::get<std::string>(o_bv3) );
+}
+
+TEST_SUITE("std_variant");
+
+TEST_CASE("binary_std_variant")
+{
+  test_std_variant<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+TEST_CASE("portable_binary_std_variant")
+{
+  test_std_variant<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
+TEST_CASE("xml_std_variant")
+{
+  test_std_variant<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+TEST_CASE("json_std_variant")
+{
+  test_std_variant<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+TEST_SUITE_END();
+
+#endif // is c++17


### PR DESCRIPTION
The test and code has been written in similar style to that of the existing support for `boost_variant`, I hope this is fine. For the tests to run one shall pass `-DCMAKE_CXX_STANDARD=17` to `cmake`.