### PR TITLE
Fix inability to pass constant pointer to BinaryOutputArchive

### DIFF
--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -210,7 +210,8 @@ namespace cereal
   {
     //! Internally store the pointer as a void *, keeping const if created with
     //! a const pointer
-    using PT = typename std::conditional<std::is_const<typename std::remove_pointer<T>::type>::value,
+    using unwrapped = typename std::remove_pointer<typename std::remove_reference<T>::type>::type;
+    using PT = typename std::conditional<std::is_const<unwrapped>::value,
                                          const void *,
                                          void *>::type;
 


### PR DESCRIPTION
Cereal tries to unwrap T* from a pointer, and then checks whether T is
a const. Unfortunately cereal::binary_data() accepts T&&, thus the code
in question gets T*& instead, effectively making the `remove_pointer` a
no-op, and forcing `is_const` check to fail. An example of a failing code:

```c++
#include <cereal/archives/binary.hpp>

struct MyClass {
    uint8_t a;

    template<class Archive>
    void load(Archive& archive) {
        archive(a);
    }
};

template<typename T>
T deserialize(const uint8_t dat[], uint sz_dat) {
    std::stringstream ss(std::ios::binary | std::ios::out | std::ios::in);
    cereal::BinaryOutputArchive arr_to_ss = {ss};
    arr_to_ss(cereal::binary_data(dat, sz_dat));

    cereal::BinaryInputArchive ss_to_MyClass(ss);
    T t;
    ss_to_MyClass(t);
    return t;
}

int main()
{
    uint8_t arr[] = {1};
    MyClass myclass = deserialize<MyClass>(arr, sizeof(arr));
}
```

```
$ g++ test3.cpp -o a           
In file included from /usr/include/cereal/access.hpp:38:0,
                 from /usr/include/cereal/details/traits.hpp:43,
                 from /usr/include/cereal/cereal.hpp:43,
                 from /usr/include/cereal/archives/binary.hpp:32,
                 from test3.cpp:1:
/usr/include/cereal/details/helpers.hpp: In instantiation of ‘cereal::BinaryData<T>::BinaryData(T&&, uint64_t) [with T = const unsigned char*&; uint64_t = long unsigned int]’:
/usr/include/cereal/cereal.hpp:82:40:   required from ‘cereal::BinaryData<T> cereal::binary_data(T&&, size_t) [with T = const unsigned char*&; size_t = long unsigned int]’
test3.cpp:16:34:   required from ‘T deserialize(const uint8_t*, uint) [with T = MyClass; uint8_t = unsigned char; uint = unsigned int]’
test3.cpp:27:60:   required from here
/usr/include/cereal/details/helpers.hpp:218:72: error: invalid conversion from ‘const void*’ to ‘cereal::BinaryData<const unsigned char*&>::PT {aka void*}’ [-fpermissive]
     BinaryData( T && d, uint64_t s ) : data(std::forward<T>(d)), size(s) {}
```

Fix the problem by unwrapping the type from a reference first.

edit: added error output for the example.