### PR TITLE
Change StaticObject instance management to hopefully avoid UBSAN

### DIFF
--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -67,13 +67,12 @@ namespace cereal
     class CEREAL_DLL_EXPORT StaticObject
     {
       private:
-        //! Forces instantiation at pre-execution time
-        static void instantiate( T const * ) {}
 
         static T & create()
         {
           static T t;
-          instantiate(&instance);
+          //! Forces instantiation at pre-execution time
+          (void)instance;
           return t;
         }
 


### PR DESCRIPTION
The static-object hack currently used requires passing an
uninitialized reference as a reference.  This fix uses a cast
to void to hopefully avoid that undefined behavior.