### PR TITLE
Fix self-include in cereal.hpp

### DIFF
--- a/include/cereal/types/common.hpp
+++ b/include/cereal/types/common.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_COMMON_HPP_
 #define CEREAL_TYPES_COMMON_HPP_
 
-#include "cereal/cereal.hpp"
+#include "cereal/macros.hpp"
 
 namespace cereal
 {


### PR DESCRIPTION
cereal.hpp included types/common.hpp which again included
cereal.hpp. Although most compilers optimized this away, static
analysis tools produced a warning.

As types/common.hpp only needs the macros, the include was swapped
for macros.hpp which fixes this issue.

Signed-off-by: Topi Kuutela <topi.kuutela@nokia.com>