### PR TITLE
Changed serialised index type of std::variant to std::int32_t

### DIFF
--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -32,6 +32,7 @@
 
 #include "cereal/cereal.hpp"
 #include <variant>
+#include <cstdint>
 
 namespace cereal
 {
@@ -80,7 +81,7 @@ namespace cereal
   template <class Archive, typename VariantType1, typename... VariantTypes> inline
   void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::variant<VariantType1, VariantTypes...> const & variant )
   {
-    auto index = variant.index();
+    std::uint32_t index = variant.index();
     ar( CEREAL_NVP_("index", index) );
     variant_detail::variant_save_visitor<Archive> visitor(ar);
     std::visit(visitor, variant);
@@ -92,7 +93,7 @@ namespace cereal
   {
     using variant_t = typename std::variant<VariantTypes...>;
 
-    decltype(variant.index()) index;
+    std::uint32_t index;
     ar( CEREAL_NVP_("index", index) );
     if(index >= std::variant_size_v<variant_t>)
       throw Exception("Invalid 'index' selector when deserializing std::variant");

--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -81,7 +81,7 @@ namespace cereal
   template <class Archive, typename VariantType1, typename... VariantTypes> inline
   void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::variant<VariantType1, VariantTypes...> const & variant )
   {
-    std::int32_t index = variant.index();
+    std::int32_t index = static_cast<std::int32_t>(variant.index());
     ar( CEREAL_NVP_("index", index) );
     variant_detail::variant_save_visitor<Archive> visitor(ar);
     std::visit(visitor, variant);

--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -81,7 +81,7 @@ namespace cereal
   template <class Archive, typename VariantType1, typename... VariantTypes> inline
   void CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::variant<VariantType1, VariantTypes...> const & variant )
   {
-    std::uint32_t index = variant.index();
+    std::int32_t index = variant.index();
     ar( CEREAL_NVP_("index", index) );
     variant_detail::variant_save_visitor<Archive> visitor(ar);
     std::visit(visitor, variant);
@@ -93,7 +93,7 @@ namespace cereal
   {
     using variant_t = typename std::variant<VariantTypes...>;
 
-    std::uint32_t index;
+    std::int32_t index;
     ar( CEREAL_NVP_("index", index) );
     if(index >= std::variant_size_v<variant_t>)
       throw Exception("Invalid 'index' selector when deserializing std::variant");

--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -95,7 +95,7 @@ namespace cereal
 
     std::int32_t index;
     ar( CEREAL_NVP_("index", index) );
-    if(index >= std::variant_size_v<variant_t>)
+    if(index >= static_cast<std::int32_t>(std::variant_size_v<variant_t>))
       throw Exception("Invalid 'index' selector when deserializing std::variant");
 
     variant_detail::load_variant<0, variant_t, VariantTypes...>(ar, index, variant);


### PR DESCRIPTION
This makes saving & loading std::variant cross-platform.