### PR TITLE
remove default case in switch of enum

### DIFF
--- a/include/cereal/types/bitset.hpp
+++ b/include/cereal/types/bitset.hpp
@@ -167,8 +167,6 @@ namespace cereal
         }
         break;
       }
-      default:
-        throw Exception("Invalid bitset data representation");
     }
   }
 } // namespace cereal


### PR DESCRIPTION
I'd recommend removing `default` cases from `switch` statements for enums that are supposed to cover all cases.  (In fact, Clang warns about this.)

Not providing a `default` case is better because if the `enum` ever is enlarged by somebody, the compiler can warn (`-Wswitch-enum`) that it is unhandled in the `switch` statement.