### PR TITLE
Added const to the member and constructor of binaryinputarchive

### DIFF
--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -89,7 +89,7 @@ namespace cereal
   {
     public:
       //! Construct, loading from the provided stream
-      BinaryInputArchive(std::istream & stream) :
+      BinaryInputArchive(const std::istream & stream) :
         InputArchive<BinaryInputArchive, AllowEmptyClassElision>(this),
         itsStream(stream)
       { }
@@ -106,7 +106,7 @@ namespace cereal
       }
 
     private:
-      std::istream & itsStream;
+      const std::istream & itsStream;
   };
 
   // ######################################################################


### PR DESCRIPTION
Can't see a reason why it would need to modify the stream. Tests all seem to pass.