### PR TITLE
Use relative instead of absolute includes

### DIFF
--- a/include/cereal/access.hpp
+++ b/include/cereal/access.hpp
@@ -34,8 +34,8 @@
 #include <cstdint>
 #include <functional>
 
-#include "cereal/macros.hpp"
-#include "cereal/details/helpers.hpp"
+#include "macros.hpp"
+#include "details/helpers.hpp"
 
 namespace cereal
 {

--- a/include/cereal/archives/adapters.hpp
+++ b/include/cereal/archives/adapters.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_ARCHIVES_ADAPTERS_HPP_
 #define CEREAL_ARCHIVES_ADAPTERS_HPP_
 
-#include "cereal/details/helpers.hpp"
+#include "../details/helpers.hpp"
 #include <utility>
 
 namespace cereal

--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -29,7 +29,7 @@
 #ifndef CEREAL_ARCHIVES_BINARY_HPP_
 #define CEREAL_ARCHIVES_BINARY_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <sstream>
 
 namespace cereal

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -29,8 +29,8 @@
 #ifndef CEREAL_ARCHIVES_JSON_HPP_
 #define CEREAL_ARCHIVES_JSON_HPP_
 
-#include "cereal/cereal.hpp"
-#include "cereal/details/util.hpp"
+#include "../cereal.hpp"
+#include "../details/util.hpp"
 
 namespace cereal
 {
@@ -56,11 +56,11 @@ namespace cereal
 #define CEREAL_RAPIDJSON_PARSE_DEFAULT_FLAGS kParseFullPrecisionFlag | kParseNanAndInfFlag
 #endif
 
-#include "cereal/external/rapidjson/prettywriter.h"
-#include "cereal/external/rapidjson/ostreamwrapper.h"
-#include "cereal/external/rapidjson/istreamwrapper.h"
-#include "cereal/external/rapidjson/document.h"
-#include "cereal/external/base64.hpp"
+#include "../external/rapidjson/prettywriter.h"
+#include "../external/rapidjson/ostreamwrapper.h"
+#include "../external/rapidjson/istreamwrapper.h"
+#include "../external/rapidjson/document.h"
+#include "../external/base64.hpp"
 
 #include <limits>
 #include <sstream>

--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -29,7 +29,7 @@
 #ifndef CEREAL_ARCHIVES_PORTABLE_BINARY_HPP_
 #define CEREAL_ARCHIVES_PORTABLE_BINARY_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <sstream>
 #include <limits>
 

--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -28,12 +28,12 @@
 */
 #ifndef CEREAL_ARCHIVES_XML_HPP_
 #define CEREAL_ARCHIVES_XML_HPP_
-#include "cereal/cereal.hpp"
-#include "cereal/details/util.hpp"
+#include "../cereal.hpp"
+#include "../details/util.hpp"
 
-#include "cereal/external/rapidxml/rapidxml.hpp"
-#include "cereal/external/rapidxml/rapidxml_print.hpp"
-#include "cereal/external/base64.hpp"
+#include "../external/rapidxml/rapidxml.hpp"
+#include "../external/rapidxml/rapidxml_print.hpp"
+#include "../external/base64.hpp"
 
 #include <sstream>
 #include <stack>

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -40,10 +40,10 @@
 #include <cstdint>
 #include <functional>
 
-#include "cereal/macros.hpp"
-#include "cereal/details/traits.hpp"
-#include "cereal/details/helpers.hpp"
-#include "cereal/types/base_class.hpp"
+#include "macros.hpp"
+#include "details/traits.hpp"
+#include "details/helpers.hpp"
+#include "types/base_class.hpp"
 
 namespace cereal
 {
@@ -1033,6 +1033,6 @@ namespace cereal
 } // namespace cereal
 
 // This include needs to come after things such as binary_data, make_nvp, etc
-#include "cereal/types/common.hpp"
+#include "types/common.hpp"
 
 #endif // CEREAL_CEREAL_HPP_

--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -37,8 +37,8 @@
 #include <unordered_map>
 #include <stdexcept>
 
-#include "cereal/macros.hpp"
-#include "cereal/details/static_object.hpp"
+#include "../macros.hpp"
+#include "../details/static_object.hpp"
 
 namespace cereal
 {

--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -45,10 +45,10 @@
 #ifndef CEREAL_DETAILS_POLYMORPHIC_IMPL_HPP_
 #define CEREAL_DETAILS_POLYMORPHIC_IMPL_HPP_
 
-#include "cereal/details/polymorphic_impl_fwd.hpp"
-#include "cereal/details/static_object.hpp"
-#include "cereal/types/memory.hpp"
-#include "cereal/types/string.hpp"
+#include "polymorphic_impl_fwd.hpp"
+#include "static_object.hpp"
+#include "../types/memory.hpp"
+#include "../types/string.hpp"
 #include <functional>
 #include <typeindex>
 #include <map>

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -28,7 +28,7 @@
 #ifndef CEREAL_DETAILS_STATIC_OBJECT_HPP_
 #define CEREAL_DETAILS_STATIC_OBJECT_HPP_
 
-#include "cereal/macros.hpp"
+#include "../macros.hpp"
 
 #if CEREAL_THREAD_SAFE
 #include <mutex>

--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -39,8 +39,8 @@
 #include <type_traits>
 #include <typeindex>
 
-#include "cereal/macros.hpp"
-#include "cereal/access.hpp"
+#include "../macros.hpp"
+#include "../access.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/array.hpp
+++ b/include/cereal/types/array.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_ARRAY_HPP_
 #define CEREAL_TYPES_ARRAY_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <array>
 
 namespace cereal

--- a/include/cereal/types/base_class.hpp
+++ b/include/cereal/types/base_class.hpp
@@ -30,8 +30,8 @@
 #ifndef CEREAL_TYPES_BASE_CLASS_HPP_
 #define CEREAL_TYPES_BASE_CLASS_HPP_
 
-#include "cereal/details/traits.hpp"
-#include "cereal/details/polymorphic_impl_fwd.hpp"
+#include "../details/traits.hpp"
+#include "../details/polymorphic_impl_fwd.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/bitset.hpp
+++ b/include/cereal/types/bitset.hpp
@@ -30,8 +30,8 @@
 #ifndef CEREAL_TYPES_BITSET_HPP_
 #define CEREAL_TYPES_BITSET_HPP_
 
-#include "cereal/cereal.hpp"
-#include "cereal/types/string.hpp"
+#include "../cereal.hpp"
+#include "string.hpp"
 #include <bitset>
 
 namespace cereal

--- a/include/cereal/types/boost_variant.hpp
+++ b/include/cereal/types/boost_variant.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_BOOST_VARIANT_HPP_
 #define CEREAL_TYPES_BOOST_VARIANT_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <boost/variant.hpp>
 #include <boost/mpl/size.hpp>
 

--- a/include/cereal/types/common.hpp
+++ b/include/cereal/types/common.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_COMMON_HPP_
 #define CEREAL_TYPES_COMMON_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/concepts/pair_associative_container.hpp
+++ b/include/cereal/types/concepts/pair_associative_container.hpp
@@ -31,7 +31,7 @@
 #ifndef CEREAL_CONCEPTS_PAIR_ASSOCIATIVE_CONTAINER_HPP_
 #define CEREAL_CONCEPTS_PAIR_ASSOCIATIVE_CONTAINER_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../../cereal.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/deque.hpp
+++ b/include/cereal/types/deque.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_DEQUE_HPP_
 #define CEREAL_TYPES_DEQUE_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <deque>
 
 namespace cereal

--- a/include/cereal/types/forward_list.hpp
+++ b/include/cereal/types/forward_list.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_FORWARD_LIST_HPP_
 #define CEREAL_TYPES_FORWARD_LIST_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <forward_list>
 
 namespace cereal

--- a/include/cereal/types/list.hpp
+++ b/include/cereal/types/list.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_LIST_HPP_
 #define CEREAL_TYPES_LIST_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <list>
 
 namespace cereal

--- a/include/cereal/types/map.hpp
+++ b/include/cereal/types/map.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_MAP_HPP_
 #define CEREAL_TYPES_MAP_HPP_
 
-#include "cereal/types/concepts/pair_associative_container.hpp"
+#include "concepts/pair_associative_container.hpp"
 #include <map>
 
 #endif // CEREAL_TYPES_MAP_HPP_

--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_SHARED_PTR_HPP_
 #define CEREAL_TYPES_SHARED_PTR_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <memory>
 #include <cstring>
 
@@ -421,7 +421,7 @@ namespace cereal
 } // namespace cereal
 
 // automatically include polymorphic support
-#include "cereal/types/polymorphic.hpp"
+#include "polymorphic.hpp"
 
 #undef CEREAL_ALIGNOF
 #endif // CEREAL_TYPES_SHARED_PTR_HPP_

--- a/include/cereal/types/optional.hpp
+++ b/include/cereal/types/optional.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_STD_OPTIONAL_
 #define CEREAL_TYPES_STD_OPTIONAL_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <optional>
 
 namespace cereal {

--- a/include/cereal/types/polymorphic.hpp
+++ b/include/cereal/types/polymorphic.hpp
@@ -30,13 +30,13 @@
 #ifndef CEREAL_TYPES_POLYMORPHIC_HPP_
 #define CEREAL_TYPES_POLYMORPHIC_HPP_
 
-#include "cereal/cereal.hpp"
-#include "cereal/types/memory.hpp"
+#include "../cereal.hpp"
+#include "memory.hpp"
 
-#include "cereal/details/util.hpp"
-#include "cereal/details/helpers.hpp"
-#include "cereal/details/traits.hpp"
-#include "cereal/details/polymorphic_impl.hpp"
+#include "../details/util.hpp"
+#include "../details/helpers.hpp"
+#include "../details/traits.hpp"
+#include "../details/polymorphic_impl.hpp"
 
 #ifdef _MSC_VER
 #define CEREAL_STATIC_CONSTEXPR static

--- a/include/cereal/types/queue.hpp
+++ b/include/cereal/types/queue.hpp
@@ -30,13 +30,13 @@
 #ifndef CEREAL_TYPES_QUEUE_HPP_
 #define CEREAL_TYPES_QUEUE_HPP_
 
-#include "cereal/details/helpers.hpp"
+#include "../details/helpers.hpp"
 #include <queue>
 
 // The default container for queue is deque, so let's include that too
-#include "cereal/types/deque.hpp"
+#include "deque.hpp"
 // The default comparator for queue is less
-#include "cereal/types/functional.hpp"
+#include "functional.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/set.hpp
+++ b/include/cereal/types/set.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_SET_HPP_
 #define CEREAL_TYPES_SET_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <set>
 
 namespace cereal

--- a/include/cereal/types/stack.hpp
+++ b/include/cereal/types/stack.hpp
@@ -30,11 +30,11 @@
 #ifndef CEREAL_TYPES_STACK_HPP_
 #define CEREAL_TYPES_STACK_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <stack>
 
 // The default container for stack is deque, so let's include that too
-#include "cereal/types/deque.hpp"
+#include "deque.hpp"
 
 namespace cereal
 {

--- a/include/cereal/types/string.hpp
+++ b/include/cereal/types/string.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_STRING_HPP_
 #define CEREAL_TYPES_STRING_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <string>
 
 namespace cereal

--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_TUPLE_HPP_
 #define CEREAL_TYPES_TUPLE_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <tuple>
 
 namespace cereal

--- a/include/cereal/types/unordered_map.hpp
+++ b/include/cereal/types/unordered_map.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_UNORDERED_MAP_HPP_
 #define CEREAL_TYPES_UNORDERED_MAP_HPP_
 
-#include "cereal/types/concepts/pair_associative_container.hpp"
+#include "concepts/pair_associative_container.hpp"
 #include <unordered_map>
 
 #endif // CEREAL_TYPES_UNORDERED_MAP_HPP_

--- a/include/cereal/types/unordered_set.hpp
+++ b/include/cereal/types/unordered_set.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_UNORDERED_SET_HPP_
 #define CEREAL_TYPES_UNORDERED_SET_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <unordered_set>
 
 namespace cereal

--- a/include/cereal/types/utility.hpp
+++ b/include/cereal/types/utility.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_UTILITY_HPP_
 #define CEREAL_TYPES_UTILITY_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <utility>
 
 namespace cereal

--- a/include/cereal/types/valarray.hpp
+++ b/include/cereal/types/valarray.hpp
@@ -32,7 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef CEREAL_TYPES_VALARRAY_HPP_
 #define CEREAL_TYPES_VALARRAY_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <valarray>
 
 namespace cereal

--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_STD_VARIANT_HPP_
 #define CEREAL_TYPES_STD_VARIANT_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <variant>
 #include <cstdint>
 

--- a/include/cereal/types/vector.hpp
+++ b/include/cereal/types/vector.hpp
@@ -30,7 +30,7 @@
 #ifndef CEREAL_TYPES_VECTOR_HPP_
 #define CEREAL_TYPES_VECTOR_HPP_
 
-#include "cereal/cereal.hpp"
+#include "../cereal.hpp"
 #include <vector>
 
 namespace cereal


### PR DESCRIPTION
This makes it a lot easier to use cereal by just dropping the include folder in your project without changing any compile flags, as one can use `#include "third_party/cereal/cereal.hpp"` for example. This was requested here: https://github.com/USCiLab/cereal/issues/346#issuecomment-251151016.