### PR TITLE
README: mention that library is not thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ cereal - A C++11 library for serialization
 
 <img src="http://uscilab.github.io/cereal/assets/img/cerealboxside.png" align="right"/><p>cereal is a header-only C++11 serialization library.  cereal takes arbitrary data types and reversibly turns them into different representations, such as compact binary encodings, XML, or JSON.  cereal was designed to be fast, light-weight, and easy to extend - it has no external dependencies and can be easily bundled with other code or used standalone.</p>
 
+It is [not thread-safe](https://uscilab.github.io/cereal/assets/doxygen/macros_8hpp.html#a89aa4dfbafa0236d0da6aa7bec573f35).
+
 ### cereal has great documentation
 
 Looking for more information on how cereal works and its documentation?  Visit [cereal's web page](http://USCiLab.github.com/cereal) to get the latest information.


### PR DESCRIPTION
It's such a big deal, it should be among the first things a person gotta know!
~~I certainly didn't, it led to hours of frustration for why when I have a bunch
of clients communicating with a server (a thread per client), sometimes I'm
getting packets duplicated, even though clients sent them correct. It costed
lots of energy to pin down to deserialization, and no, the CEREAL_THREAD_SAFE
didn't help — probably because, per the linked docs, you still not allowed to
access the same archive from multiple threads.~~ *(upd: the threading problem turned to be irrelevant to Cereal. The point stands though.)*

It's such a surprise — why would a serialization library, aiming to be
header-only through C++11 features, use a global state? It's a rhetoric
question, maybe there is a reason, but let's at least make sure it's less
likely for new peoples to fall into threading trap.