### PR TITLE
grant constexpr access to cereal class version

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -164,6 +164,8 @@ namespace cereal
     #define CEREAL_UNUSED_FUNCTION static void unused() { (void)version; }
   #endif
 
+  template <typename T> struct Version;
+
   // ######################################################################
   //! Defines a class version for some type
   /*! Versioning information is optional and adds some small amount of
@@ -212,6 +214,11 @@ namespace cereal
       }
       @endcode
 
+      Having defined CEREAL_CLASS_VERSION for a given type Mytype also defines
+      the constexpr variable Version<Mytype>::value.  This can be used for
+      static_asserts in functions that need to be updated when Mytype is
+      updated.
+
       Interfaces for other forms of serialization functions is similar.  This
       macro should be placed at global scope.
       @ingroup Utility */
@@ -230,7 +237,11 @@ namespace cereal
     }; /* end Version */                                                         \
     const std::uint32_t Version<TYPE>::version =                                 \
       Version<TYPE>::registerVersion();                                          \
-  } } // end namespaces
+  }                                                                              \
+  template <> struct Version<TYPE> {                                             \
+    static CEREAL_INLINE_VARIABLE constexpr std::uint32_t value{VERSION_NUMBER}; \
+  };                                                                             \
+  } // end namespaces
 
   // ######################################################################
   //! The base output archive class

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -217,7 +217,8 @@ namespace cereal
       Having defined CEREAL_CLASS_VERSION for a given type Mytype also defines
       the constexpr variable Version<Mytype>::value.  This can be used for
       static_asserts in functions that need to be updated when Mytype is
-      updated.
+      updated.  (It is not constexpr on older MSVC versions that do not support
+      constexpr.)
 
       Interfaces for other forms of serialization functions is similar.  This
       macro should be placed at global scope.
@@ -239,7 +240,8 @@ namespace cereal
       Version<TYPE>::registerVersion();                                          \
   }                                                                              \
   template <> struct Version<TYPE> {                                             \
-    static CEREAL_INLINE_VARIABLE constexpr std::uint32_t value{VERSION_NUMBER}; \
+    static CEREAL_INLINE_VARIABLE CEREAL_CONSTEXPR std::uint32_t                 \
+      value{VERSION_NUMBER};                                                     \
   };                                                                             \
   } // end namespaces
 

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -240,8 +240,7 @@ namespace cereal
       Version<TYPE>::registerVersion();                                          \
   }                                                                              \
   template <> struct Version<TYPE> {                                             \
-    static CEREAL_INLINE_VARIABLE CEREAL_CONSTEXPR std::uint32_t                 \
-      value{VERSION_NUMBER};                                                     \
+    static CEREAL_CONSTEXPR std::uint32_t value{VERSION_NUMBER};                 \
   };                                                                             \
   } // end namespaces
 

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -143,4 +143,10 @@
 #define CEREAL_HAS_CPP14
 #endif
 
+#ifdef CEREAL_HAS_CPP17
+#define CEREAL_INLINE_VARIABLE inline
+#else
+#define CEREAL_INLINE_VARIABLE
+#endif
+
 #endif // CEREAL_MACROS_HPP_

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -143,12 +143,6 @@
 #define CEREAL_HAS_CPP14
 #endif
 
-#ifdef CEREAL_HAS_CPP17
-#define CEREAL_INLINE_VARIABLE inline
-#else
-#define CEREAL_INLINE_VARIABLE
-#endif
-
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 #define CEREAL_CONSTEXPR constexpr
 #else

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -149,4 +149,10 @@
 #define CEREAL_INLINE_VARIABLE
 #endif
 
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
+#define CEREAL_CONSTEXPR constexpr
+#else
+#define CEREAL_CONSTEXPR
+#endif
+
 #endif // CEREAL_MACROS_HPP_

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -152,7 +152,7 @@
 #if !defined(_MSC_VER) || _MSC_VER >= 1900
 #define CEREAL_CONSTEXPR constexpr
 #else
-#define CEREAL_CONSTEXPR
+#define CEREAL_CONSTEXPR const
 #endif
 
 #endif // CEREAL_MACROS_HPP_


### PR DESCRIPTION
This patch allows accessing the class version set with the `CEREAL_CLASS_VERSION` macro in a `constexpr` manner.

The use case is as follows:
Suppose you have a function `f` that does something with a type `A` that has a cereal version set.  Now whenever `A` changes, you want to make sure that `f` is updated accordingly.  A nice way to enforce this is to simply `static_assert(cereal::Version<A>::value == 2, "A has been changed, please update f accordingly!");`.  However, there was no way as of yet to access the version number once it was set.