### PR TITLE
add missing std::monostate serialization to variant.hpp

### DIFF
--- a/include/cereal/types/variant.hpp
+++ b/include/cereal/types/variant.hpp
@@ -99,6 +99,10 @@ namespace cereal
 
     variant_detail::load_variant<0, variant_t, VariantTypes...>(ar, index, variant);
   }
+
+  //! Serializing a std::monostate
+  template <class Archive>
+  void CEREAL_SERIALIZE_FUNCTION_NAME( Archive &, std::monostate const & ) {}
 } // namespace cereal
 
 #endif // CEREAL_TYPES_STD_VARIANT_HPP_


### PR DESCRIPTION
`std::monostate` should have its (trivial) serialization defined when `std::variant` is used.  It is declared in `<variant>`, thus it makes sense to include the serialization in `variant.hpp` I think.