### PR TITLE
Fix CEREAL_DLL_EXPORT for gcc/clang

### DIFF
--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -48,7 +48,7 @@
 #   define CEREAL_DLL_EXPORT __declspec(dllexport)
 #   define CEREAL_USED
 #else // clang or gcc
-#   define CEREAL_DLL_EXPORT
+#   define CEREAL_DLL_EXPORT __attribute__ ((visibility("default")))
 #   define CEREAL_USED __attribute__ ((__used__))
 #endif
 


### PR DESCRIPTION
If project is built with `-fvisibility=hidden` flag (mimics VS default
behaviour) then `CEREAL_DLL_EXPORT` must expand to explicit "default"
visibility attribute to actually force compiler to export marked symbol
from produced shared object.