### PR TITLE
Remove template parameter `Archive` from `InputBindingsMap` and `OutputBindingsMap`

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -449,7 +449,6 @@ namespace cereal
         type, containing entries for every registered type that describe how to
         properly cast the type to its real type in polymorphic scenarios for
         shared_ptr, weak_ptr, and unique_ptr. */
-    template <class Archive>
     struct OutputBindingMap
     {
       //! A serializer function
@@ -468,7 +467,14 @@ namespace cereal
       };
 
       //! A map of serializers for pointers of all registered types
-      std::map<std::type_index, Serializers> map;
+      using Serializers_map = std::map<std::type_index, Serializers>;
+      //! A map of archive typeid -> map of serializers for given archive
+      using Archives_map = std::map<std::type_index, Serializers_map>;
+      Archives_map archives_map;
+
+      //! Obtain serializers map for given archive
+      template<typename Archive>
+      Serializers_map& map() { return archives_map[typeid(Archive)]; }
     };
 
     //! An empty noop deleter
@@ -479,7 +485,6 @@ namespace cereal
         type, containing entries for every registered type that describe how to
         properly cast the type to its real type in polymorphic scenarios for
         shared_ptr, weak_ptr, and unique_ptr. */
-    template <class Archive>
     struct InputBindingMap
     {
       //! Shared ptr serializer function
@@ -500,7 +505,14 @@ namespace cereal
       };
 
       //! A map of serializers for pointers of all registered types
-      std::map<std::string, Serializers> map;
+      using Serializers_map = std::map<std::string, Serializers>;
+      //! A map of archive typeid -> map of serializers for given archive
+      using Archives_map = std::map<std::type_index, Serializers_map>;
+      Archives_map archives_map;
+
+      //! Obtain serializers map for given archive
+      template<typename Archive>
+      Serializers_map& map() { return archives_map[typeid(Archive)]; }
     };
 
     // forward decls for archives from cereal.hpp
@@ -517,15 +529,15 @@ namespace cereal
       //! Initialize the binding
       InputBindingCreator()
       {
-        auto & map = StaticObject<InputBindingMap<Archive>>::getInstance().map;
-        auto lock = StaticObject<InputBindingMap<Archive>>::lock();
+        auto & map = StaticObject<InputBindingMap>::getInstance().map<Archive>();
+        auto lock = StaticObject<InputBindingMap>::lock();
         auto key = std::string(binding_name<T>::name());
         auto lb = map.lower_bound(key);
 
         if (lb != map.end() && lb->first == key)
           return;
 
-        typename InputBindingMap<Archive>::Serializers serializers;
+        typename InputBindingMap::Serializers serializers;
 
         serializers.shared_ptr =
           [](void * arptr, std::shared_ptr<void> & dptr, std::type_info const & baseInfo)
@@ -637,14 +649,15 @@ namespace cereal
       //! Initialize the binding
       OutputBindingCreator()
       {
-        auto & map = StaticObject<OutputBindingMap<Archive>>::getInstance().map;
+        auto & map = StaticObject<OutputBindingMap>::getInstance().map<Archive>();
+        auto lock = StaticObject<OutputBindingMap>::lock();
         auto key = std::type_index(typeid(T));
         auto lb = map.lower_bound(key);
 
         if (lb != map.end() && lb->first == key)
           return;
 
-        typename OutputBindingMap<Archive>::Serializers serializers;
+        typename OutputBindingMap::Serializers serializers;
 
         serializers.shared_ptr =
           [&](void * arptr, void const * dptr, std::type_info const & baseInfo)

--- a/include/cereal/external/rapidjson/document.h
+++ b/include/cereal/external/rapidjson/document.h
@@ -1936,7 +1936,7 @@ private:
         if (count) {
             GenericValue* e = static_cast<GenericValue*>(allocator.Malloc(count * sizeof(GenericValue)));
             SetElementsPointer(e);
-            std::memcpy(e, values, count * sizeof(GenericValue));
+            std::memcpy((void*)e, values, count * sizeof(GenericValue));
         }
         else
             SetElementsPointer(0);
@@ -1949,7 +1949,7 @@ private:
         if (count) {
             Member* m = static_cast<Member*>(allocator.Malloc(count * sizeof(Member)));
             SetMembersPointer(m);
-            std::memcpy(m, members, count * sizeof(Member));
+            std::memcpy((void*)m, members, count * sizeof(Member));
         }
         else
             SetMembersPointer(0);

--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -154,7 +154,7 @@ namespace cereal
         {
           if( !itsRestored )
           {
-            std::memcpy( itsPtr, &itsState, sizeof(ParentType) );
+            std::memcpy( (void*)itsPtr, &itsState, sizeof(ParentType) );
             itsRestored = true;
           }
         }

--- a/include/cereal/types/polymorphic.hpp
+++ b/include/cereal/types/polymorphic.hpp
@@ -194,12 +194,12 @@ namespace cereal
     //! Get an input binding from the given archive by deserializing the type meta data
     /*! @internal */
     template<class Archive> inline
-    typename ::cereal::detail::InputBindingMap<Archive>::Serializers getInputBinding(Archive & ar, std::uint32_t const nameid)
+    typename ::cereal::detail::InputBindingMap::Serializers getInputBinding(Archive & ar, std::uint32_t const nameid)
     {
       // If the nameid is zero, we serialized a null pointer
       if(nameid == 0)
       {
-        typename ::cereal::detail::InputBindingMap<Archive>::Serializers emptySerializers;
+        typename ::cereal::detail::InputBindingMap::Serializers emptySerializers;
         emptySerializers.shared_ptr = [](void*, std::shared_ptr<void> & ptr, std::type_info const &) { ptr.reset(); };
         emptySerializers.unique_ptr = [](void*, std::unique_ptr<void, ::cereal::detail::EmptyDeleter<void>> & ptr, std::type_info const &) { ptr.reset( nullptr ); };
         return emptySerializers;
@@ -214,7 +214,7 @@ namespace cereal
       else
         name = ar.getPolymorphicName(nameid);
 
-      auto const & bindingMap = detail::StaticObject<detail::InputBindingMap<Archive>>::getInstance().map;
+      auto const & bindingMap = detail::StaticObject<detail::InputBindingMap>::getInstance().map<Archive>();
 
       auto binding = bindingMap.find(name);
       if(binding == bindingMap.end())
@@ -317,7 +317,7 @@ namespace cereal
     // of an abstract object
     //  this implies we need to do the lookup
 
-    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap<Archive>>::getInstance().map;
+    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap>::getInstance().map<Archive>();
 
     auto binding = bindingMap.find(std::type_index(ptrinfo));
     if(binding == bindingMap.end())
@@ -352,7 +352,7 @@ namespace cereal
       return;
     }
 
-    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap<Archive>>::getInstance().map;
+    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap>::getInstance().map<Archive>();
 
     auto binding = bindingMap.find(std::type_index(ptrinfo));
     if(binding == bindingMap.end())
@@ -416,7 +416,7 @@ namespace cereal
     // of an abstract object
     //  this implies we need to do the lookup
 
-    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap<Archive>>::getInstance().map;
+    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap>::getInstance().map<Archive>();
 
     auto binding = bindingMap.find(std::type_index(ptrinfo));
     if(binding == bindingMap.end())
@@ -451,7 +451,7 @@ namespace cereal
       return;
     }
 
-    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap<Archive>>::getInstance().map;
+    auto const & bindingMap = detail::StaticObject<detail::OutputBindingMap>::getInstance().map<Archive>();
 
     auto binding = bindingMap.find(std::type_index(ptrinfo));
     if(binding == bindingMap.end())


### PR DESCRIPTION
`Archive` isn't directly needed for any content in binding
structs and required only to instantiate different global static
maps for different archives.

This commit turns `InputBindingsMap` and `OutputBindingsMap` into
non-templated structs and modifies binding maps to include archive's
typeid, such that they describe relation: `typeid(Archive) ->
per-archive binding map`.

That way only two global static objects will be created in runtime (for
input and output bindings respectively) in each library/executable. Also
types of these globals are independent from included archives and known
beforehand.
