### PR TITLE
Fix uninitialized variables.

### DIFF
--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -224,7 +224,7 @@ namespace cereal
         itsStream(stream),
         itsConvertEndianness( false )
       {
-        uint8_t streamLittleEndian;
+        uint8_t streamLittleEndian{0};
         this->operator()( streamLittleEndian );
         itsConvertEndianness = options.is_little_endian() ^ streamLittleEndian;
       }

--- a/include/cereal/types/string.hpp
+++ b/include/cereal/types/string.hpp
@@ -50,7 +50,7 @@ namespace cereal
   typename std::enable_if<traits::is_input_serializable<BinaryData<CharT>, Archive>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME(Archive & ar, std::basic_string<CharT, Traits, Alloc> & str)
   {
-    size_type size;
+    size_type size{};
     ar( make_size_tag( size ) );
     str.resize(static_cast<std::size_t>(size));
     ar( binary_data( const_cast<CharT *>( str.data() ), static_cast<std::size_t>(size) * sizeof(CharT) ) );


### PR DESCRIPTION
clang-tidy found an issue with the cereal library during static
analysis. It indicated that data could end up uninitialized.  The fix
involves setting reasonable default values before values are read by
the cereal library.

The contribution is being made by Autodesk Inc. under the terms of the
BSD license.