### PR TITLE
Added the flush to the xml archive

### DIFF
--- a/include/cereal/archives/xml.hpp
+++ b/include/cereal/archives/xml.hpp
@@ -163,6 +163,7 @@ namespace cereal
         const int flags = itsIndent ? 0x0 : rapidxml::print_no_indenting;
         rapidxml::print( itsStream, itsXML, flags );
         itsXML.clear();
+        itsStream.flush();
       }
 
       //! Saves some binary data, encoded as a base64 string, with an optional name


### PR DESCRIPTION
Contrary to the expected behaviour and of the behaviour of the other archives, the XML will not flush the stream on destruction so that one needs a post-mortem close or flush on the stream to complete the serialization