### PR TITLE
Put static hash initialization of type under mutex

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -488,9 +488,9 @@ namespace cereal
       template <class T> inline
       std::uint32_t registerClassVersion()
       {
+        const auto lock = detail::StaticObject<detail::Versions>::lock();
         static const auto hash = std::type_index(typeid(T)).hash_code();
         const auto insertResult = itsVersionedTypes.insert( hash );
-        const auto lock = detail::StaticObject<detail::Versions>::lock();
         const auto version =
           detail::StaticObject<detail::Versions>::getInstance().find( hash, detail::Version<T>::version );
 


### PR DESCRIPTION
Since Visual Studio 2013 does not support `Dynamic initialization and destruction with concurrency` cereal hash generation for types may fail in multi threaded app even if  `CEREAL_THREAD_SAFE=1`