### PR TITLE
Allow include-less usage of make_nvp (using ADL)

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -274,7 +274,7 @@ namespace cereal
 
       //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
       /*! @relates AdlTag */
-      static constexpr AdlTag cereal_adl() { return AdlTag{}; }
+      static AdlTag cereal_adl() { return AdlTag{}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */
@@ -664,7 +664,7 @@ namespace cereal
 
       //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
       /*! @relates AdlTag */
-      static constexpr AdlTag cereal_adl() { return AdlTag{}; }
+      static AdlTag cereal_adl() { return AdlTag{}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -274,7 +274,7 @@ namespace cereal
 
       //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
       /*! @relates AdlTag */
-      static constexpr AdlTag cereal_adl() { return {}; }
+      static constexpr AdlTag cereal_adl() { return AdlTag{}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */
@@ -664,7 +664,7 @@ namespace cereal
 
       //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
       /*! @relates AdlTag */
-      static constexpr AdlTag cereal_adl() { return {}; }
+      static constexpr AdlTag cereal_adl() { return AdlTag{}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -30,6 +30,7 @@
 #define CEREAL_CEREAL_HPP_
 
 #include <type_traits>
+#include <utility>
 #include <string>
 #include <memory>
 #include <functional>
@@ -64,6 +65,17 @@ namespace cereal
   NameValuePair<T> make_nvp( const char * name, T && value )
   {
     return {name, std::forward<T>(value)};
+  }
+
+  //! Creates a name value pair. Accepts an empty type as first argument in order to allow for argument-dependent lookup (ADL).
+  /*! @relates NameValuePair
+      @relates AdlTag
+      @ingroup Utility */
+  template <class ... Args> inline
+  auto make_nvp( AdlTag, Args && ... args )
+    -> decltype(make_nvp( std::forward<Args>( args )... ))
+  {
+    return make_nvp( std::forward<Args>( args )... );
   }
 
   //! Creates a name value pair for the variable T with the same name as the variable
@@ -259,6 +271,10 @@ namespace cereal
       { }
 
       OutputArchive & operator=( OutputArchive const & ) = delete;
+
+      //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
+      /*! @relates AdlTag */
+      static constexpr AdlTag cereal_adl() { return {}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */
@@ -645,6 +661,10 @@ namespace cereal
       { }
 
       InputArchive & operator=( InputArchive const & ) = delete;
+
+      //! Provide an empty tag for argument-dependent lookup (ADL) in ::cereal
+      /*! @relates AdlTag */
+      static constexpr AdlTag cereal_adl() { return {}; }
 
       //! Serializes all passed in data
       /*! This is the primary interface for serializing data with an archive */

--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -322,6 +322,31 @@ namespace cereal
   };
 
   // ######################################################################
+  //! An empty type to enable argument-dependent lookup (ADL) from templated
+  //! serialization functions
+  /*! This tag is provided by archives in order to allow templated
+      serialization functions to find specific utilities in the cereal
+      namespace without including any cereal headers. A typical use case is:
+
+      @code{.cpp}
+      // no includes required
+      struct MyStruct
+      {
+        int a, b;
+
+        template<class Archive>
+        void serialize(Archive & archive)
+        {
+          archive( make_nvp(archive.cereal_adl(), "a", a),
+                   make_nvp(archive.cereal_adl(), "b", b) );
+        }
+      };
+      @endcode
+
+      @internal */
+  struct AdlTag {};
+
+  // ######################################################################
   //! A wrapper around a key and value for serializing data into maps.
   /*! This class just provides a grouping of keys and values into a struct for
       human readable archives. For example, XML archives will use this wrapper


### PR DESCRIPTION
**Note:** This PR is incomplete (no tests etc). Please let me know if you can imagine to merge something like this change. I would be happy to put more effort into this if there is a chance that you accept it.

In the simplest case, I can define a serializable class in a header file without including any cereal headers:

```
      struct MyStruct
      {
        int a, b;

        template<class Archive>
        void serialize(Archive & archive)
        {
          archive( a, b );
        }
      };
```

This is useful because other code may use this class without using the serialization functionality. In that case, there is no dependency on cereal. However, I am forced to `#include <cereal/cereal.hpp>` as soon as I wish to use `cereal::make_nvp`. I would like to avoid this dependency by using the following API:

```
     // no includes and no dependencies
      struct MyStruct
      {
        int a, b;

        template<class Archive>
        void serialize(Archive & archive)
        {
          archive( make_nvp(archive.cereal_adl(), "a", a),
                   make_nvp(archive.cereal_adl(), "b", b) );
        }
      };
```

See also:
 * #261 
 * https://groups.google.com/forum/#!topic/cerealcpp/vXkc7x1VqfU
