### PR TITLE
remove const check from load_minimal

### DIFF
--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -847,9 +847,6 @@ namespace cereal
         static_assert( check::valid || !check::exists, "cereal detected different types in corresponding non-member "        \
             #test_name " and " #save_name " functions. \n "                                                                  \
             "the paramater to " #test_name " must be a constant reference to the type that " #save_name " returns." );       \
-        static_assert( check::const_valid || !check::exists,                                                                 \
-            "cereal detected an invalid serialization type parameter in non-member " #test_name ".  "                        \
-            #test_name " non-member functions must accept their serialization type by non-const reference" );                \
       };                                                                                                                     \
     } /* namespace detail */                                                                                                 \
                                                                                                                              \


### PR DESCRIPTION
This PR removes the const check from the load_minimal meta programming. It "solves"  #132, #436  and likely #263 and a few others. The first of these issues are open since 2014...

I know that the check is well-intentioned in providing users with more readable error messages, but obviously it is breaking many legitimate use-cases. I have just spent full work-day trying to workaround some other obscure case the check is breaking – without success. 

Seeing the commit references in #132 apparently everyone has just started patching cereal themselves to get rid of these two lines. This is not really an option for us, we don't want to depend on non-upstreamed changes.

So I propose to remove the check altogether for now. This would really help us a lot and likely many others, as well.

Thank you!