### PR TITLE
Fix fallthrough warning for JSON archive code.

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -209,11 +209,13 @@ namespace cereal
         {
           case NodeType::StartArray:
             itsWriter.StartArray();
+            CEREAL_FALL_THROUGH;
           case NodeType::InArray:
             itsWriter.EndArray();
             break;
           case NodeType::StartObject:
             itsWriter.StartObject();
+            CEREAL_FALL_THROUGH;
           case NodeType::InObject:
             itsWriter.EndObject();
             break;

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -132,4 +132,22 @@
   #endif // end !defined(CEREAL_HAS_NOEXCEPT)
 #endif // ifndef CEREAL_NOEXCEPT
 
+
+// ######################################################################
+//! Defines the CEREAL_FALL_THROUGH macro to suppress fall-through warnings
+//! if the compiler supports it.
+#if defined __has_cpp_attribute
+  #if __has_cpp_attribute(fallthrough)
+    #define CEREAL_FALL_THROUGH [[fallthrough]]
+  #else
+    #define CEREAL_FALL_THROUGH
+  #endif
+#else
+  #if defined(__GNUC__) && __GNUC__ >= 7
+    #define CEREAL_FALL_THROUGH __attribute__ ((fallthrough))
+  #else
+    #define CEREAL_FALL_THROUGH ((void)0)
+  #endif /* __GNUC__ >= 7 */
+#endif // defined_has_cpp_attribute
+
 #endif // CEREAL_MACROS_HPP_

--- a/include/cereal/macros.hpp
+++ b/include/cereal/macros.hpp
@@ -136,18 +136,24 @@
 // ######################################################################
 //! Defines the CEREAL_FALL_THROUGH macro to suppress fall-through warnings
 //! if the compiler supports it.
+
+// Use the C++17 atribute if available
 #if defined __has_cpp_attribute
   #if __has_cpp_attribute(fallthrough)
     #define CEREAL_FALL_THROUGH [[fallthrough]]
-  #else
-    #define CEREAL_FALL_THROUGH
-  #endif
-#else
+  #endif // end __has_cpp_attribute(fallthrough)
+#endif // end defined __has_cpp_attribute
+
+// Otherwise try the non-portable GNU extension
+#ifndef CEREAL_FALL_THROUGH
   #if defined(__GNUC__) && __GNUC__ >= 7
     #define CEREAL_FALL_THROUGH __attribute__ ((fallthrough))
-  #else
-    #define CEREAL_FALL_THROUGH ((void)0)
-  #endif /* __GNUC__ >= 7 */
-#endif // defined_has_cpp_attribute
+  #endif // end __GNUC__ >= 7
+#endif // end !defined CEREAL_FALL_THROUGH
+
+// Otherwise make it a no-op
+#ifndef CEREAL_FALL_THROUGH
+  #define CEREAL_FALL_THROUGH ((void)0)
+#endif // end !defined CEREAL_FALL_THROUGH
 
 #endif // CEREAL_MACROS_HPP_


### PR DESCRIPTION
I was getting a fallthrough warning on g++ while compiling the unit tests, so I added a macro that suppresses the warning. It should also do so for c++17.