### PR TITLE
Add fall through comments to json.hpp

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -209,11 +209,13 @@ namespace cereal
         {
           case NodeType::StartArray:
             itsWriter.StartArray();
+            // fall through
           case NodeType::InArray:
             itsWriter.EndArray();
             break;
           case NodeType::StartObject:
             itsWriter.StartObject();
+            // fall through
           case NodeType::InObject:
             itsWriter.EndObject();
             break;


### PR DESCRIPTION
The -Werror flag is on by default in the CMakeLists.txt file. This will not compile when the project is included via CMake ExternalProject_Add with default settings.