### PR TITLE
Making `SizeTag` save/load easier to customize for binary oriented archives

### DIFF
--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -136,12 +136,20 @@ namespace cereal
     ar( t.value );
   }
 
-  //! Serializing SizeTags to binary
+  //! Saving size tag to binary
   template <class Archive, class T> inline
   CEREAL_ARCHIVE_RESTRICT(BinaryInputArchive, BinaryOutputArchive)
-  CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, SizeTag<T> & t )
+  CEREAL_SAVE_FUNCTION_NAME(Archive & ar, SizeTag<T> const & t)
   {
-    ar( t.size );
+      ar.template saveBinary<sizeof(t.size)>(std::addressof(t.size), sizeof(t.size));
+  }
+
+  //! Loading size tag from binary
+  template <class Archive, class T> inline
+  CEREAL_ARCHIVE_RESTRICT(BinaryInputArchive, BinaryOutputArchive)
+  CEREAL_LOAD_FUNCTION_NAME(Archive & ar, SizeTag<T> & t)
+  {
+      ar.template loadBinary<sizeof(t.size)>(std::addressof(t.size), sizeof(t.size));
   }
 
   //! Saving binary data

--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -291,12 +291,20 @@ namespace cereal
     ar( t.value );
   }
 
-  //! Serializing SizeTags to portable binary
+  //! Saving size tag to portable binary
   template <class Archive, class T> inline
   CEREAL_ARCHIVE_RESTRICT(PortableBinaryInputArchive, PortableBinaryOutputArchive)
-  CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, SizeTag<T> & t )
+  CEREAL_SAVE_FUNCTION_NAME(Archive & ar, SizeTag<T> const & t )
   {
-    ar( t.size );
+      ar.template saveBinary<sizeof(t.size)>(std::addressof(t.size), sizeof(t.size));
+  }
+
+  //! Loading size tag from portable binary
+  template <class Archive, class T> inline
+  CEREAL_ARCHIVE_RESTRICT(PortableBinaryInputArchive, PortableBinaryOutputArchive)
+  CEREAL_LOAD_FUNCTION_NAME(Archive & ar, SizeTag<T> & t)
+  {
+      ar.template loadBinary<sizeof(t.size)>(std::addressof(t.size), sizeof(t.size));
   }
 
   //! Saving binary data to portable binary


### PR DESCRIPTION
- At the current code state, the `serialize` method is being specified for `SizeTag` objects both for binary archives and portable binary archives
- This renders custom handing of `SizeTag` objects (say, [VLQ](https://en.wikipedia.org/wiki/Variable-length_quantity)) via `save/load` to fail (static assertion is being fired since `serialize` is already specified)
- The idea of this PR, is to keep the previous behavior of saving/loading the entire value of the `size` field of the `SizeTag` object via explicit `save/load` methods, yet to enable constructs like the one below
```/*
* Some explanation about 7-bit encoded int (see https://docs.microsoft.com/en-us/dotnet/api/system.io.binarywriter.write7bitencodedint?redirectedfrom=MSDN&view=netframework-4.8#System_IO_BinaryWriter_Write7BitEncodedInt_System_Int32_)
*  The integer of the value parameter is written out seven bits at a time, starting with the seven least-significant bits.
*  The high bit of a byte indicates whether there are more bytes to be written after this one.
*  If value will fit in seven bits, it takes only one byte of space. If value will not fit in seven bits, the high bit is set on the first byte and written out. value is then shifted by seven bits and the next byte is written.
*  This process is repeated until the entire integer has been written.
*/
namespace cereal
{
    template <class T> inline
    void CEREAL_SAVE_FUNCTION_NAME(PortableBinaryOutputArchive & ar, SizeTag<T> const & t)
    {
        auto value = static_cast<std::uint64_t>(t.size);
        do
        {
            auto c = static_cast<std::uint8_t>(value & 0x7F);
            value >>= 7;
            if (value)
            {
                c |= 0x80;
            }
            ar.template saveBinary<sizeof(c)>(std::addressof(c), sizeof(c));
        } while (value);
    }

    template <class T> inline
    void CEREAL_LOAD_FUNCTION_NAME(PortableBinaryInputArchive & ar, SizeTag<T> & t)
    {
        std::uint8_t c;
        t.size = 0;
        int s = 0;
        do
        {
            ar.template loadBinary<sizeof(c)>(std::addressof(c), sizeof(c));
            std::uint64_t x = (c & 0x7F);
            x <<= s;
            t.size += x;
            s += 7;
        } while (c & 0x80);
    }
}

