### PR TITLE
Fix json.hpp compilation issue when int32_t is a long

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -292,13 +292,13 @@ namespace cereal
 #else // _MSC_VER
       //! Serialize a long if it would not be caught otherwise
       template <class T, traits::EnableIf<std::is_same<T, long>::value,
-                                          !std::is_same<T, std::int32_t>::value,
+                                          !std::is_same<T, int>::value,
                                           !std::is_same<T, std::int64_t>::value> = traits::sfinae> inline
       void saveValue( T t ){ saveLong( t ); }
 
       //! Serialize an unsigned long if it would not be caught otherwise
       template <class T, traits::EnableIf<std::is_same<T, unsigned long>::value,
-                                          !std::is_same<T, std::uint32_t>::value,
+                                          !std::is_same<T, unsigned>::value,
                                           !std::is_same<T, std::uint64_t>::value> = traits::sfinae> inline
       void saveValue( T t ){ saveLong( t ); }
 #endif // _MSC_VER


### PR DESCRIPTION
When testing whether or not to define a saveValue() overload for long, test the actual set of types implemented.

Background: I tried out cereal on an embedded C++ compiler, which has a quirk that `int32_t`/`uint32_t` are defined to be `long`/`unsigned long`, rather than `int`/`unsigned int` which is common on most other platforms. json.hpp fails to compile in this case, with the error pasted below.

The issue is that in the `JSONOutputArchive` class, there is no definition of `saveValue()` that serializes longs. It looks like there is code to cater for situations like this (under the comment "Serialize a long if it would not be caught otherwise") but it doesn't work because this clause eliminates it: `EnableIf<..., !std::is_same<T, std::int32_t>::value, ...>`.

The logic in the `EnableIf<>` here doesn't match what overloads of `saveValue()` are actually defined - there are overloads for `int` and `int64_t`, but we are testing for `int32_t` and `int64_t`. I think the correct solution is to simply change `int32_t` to `int` (and ditto `uint32_t`).


~~~~~
In file included from test_json.cc:8:0:
cereal/include/cereal/archives/json.hpp: In member function 'void cereal::JSONOutputArchive::saveLong(T)':
cereal/include/cereal/archives/json.hpp:271:69: error: call of overloaded 'saveValue(int32_t)' is ambiguous
       void saveLong(T l){ saveValue( static_cast<std::int32_t>( l ) ); }
                                                                     ^
In file included from test_json.cc:8:0:
cereal/include/cereal/archives/json.hpp:246:12: note: candidate: void cereal::JSONOutputArchive::saveValue(bool)
       void saveValue(bool b)                { itsWriter.Bool(b);                                                         }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:248:12: note: candidate: void cereal::JSONOutputArchive::saveValue(int)
       void saveValue(int i)                 { itsWriter.Int(i);                                                          }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:250:12: note: candidate: void cereal::JSONOutputArchive::saveValue(unsigned int)
       void saveValue(unsigned u)            { itsWriter.Uint(u);                                                         }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:252:12: note: candidate: void cereal::JSONOutputArchive::saveValue(int64_t)
       void saveValue(int64_t i64)           { itsWriter.Int64(i64);                                                      }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:254:12: note: candidate: void cereal::JSONOutputArchive::saveValue(uint64_t)
       void saveValue(uint64_t u64)          { itsWriter.Uint64(u64);                                                     }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:256:12: note: candidate: void cereal::JSONOutputArchive::saveValue(double)
       void saveValue(double d)              { itsWriter.Double(d);                                                       }
            ^~~~~~~~~
In file included from test_json.cc:8:0:
cereal/include/cereal/archives/json.hpp: In member function 'void cereal::JSONOutputArchive::saveLong(T)':
cereal/include/cereal/archives/json.hpp:281:72: error: call of overloaded 'saveValue(uint32_t)' is ambiguous
       void saveLong(T lu){ saveValue( static_cast<std::uint32_t>( lu ) ); }
                                                                        ^
In file included from test_json.cc:8:0:
cereal/include/cereal/archives/json.hpp:246:12: note: candidate: void cereal::JSONOutputArchive::saveValue(bool)
       void saveValue(bool b)                { itsWriter.Bool(b);                                                         }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:248:12: note: candidate: void cereal::JSONOutputArchive::saveValue(int)
       void saveValue(int i)                 { itsWriter.Int(i);                                                          }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:250:12: note: candidate: void cereal::JSONOutputArchive::saveValue(unsigned int)
       void saveValue(unsigned u)            { itsWriter.Uint(u);                                                         }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:252:12: note: candidate: void cereal::JSONOutputArchive::saveValue(int64_t)
       void saveValue(int64_t i64)           { itsWriter.Int64(i64);                                                      }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:254:12: note: candidate: void cereal::JSONOutputArchive::saveValue(uint64_t)
       void saveValue(uint64_t u64)          { itsWriter.Uint64(u64);                                                     }
            ^~~~~~~~~
cereal/include/cereal/archives/json.hpp:256:12: note: candidate: void cereal::JSONOutputArchive::saveValue(double)
       void saveValue(double d)              { itsWriter.Double(d);                                                       }
            ^~~~~~~~~
~~~~~