### PR TITLE
Add compiler attributes to silence fallthrough warnings.

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -221,12 +221,18 @@ namespace cereal
           case NodeType::StartArray:
             itsWriter.StartArray();
             // fall through
+          #if defined (__cplusplus) && __cplusplus >= 201703L
+              [[fallthrough]];
+          #endif
           case NodeType::InArray:
             itsWriter.EndArray();
             break;
           case NodeType::StartObject:
             itsWriter.StartObject();
             // fall through
+          #if defined (__cplusplus) && __cplusplus >= 201703L
+              [[fallthrough]];
+          #endif
           case NodeType::InObject:
             itsWriter.EndObject();
             break;


### PR DESCRIPTION
Same fallthrough warnings from regex.h are ignored, maybe they should be modified too.