### PR TITLE
Cleanly compile cereal for C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,10 @@ else()
 
 endif()
 
+if (CMAKE_CXX_STANDARD GREATER 17)
+    set(SKIP_PERFORMANCE_COMPARISON ON)
+endif()
+
 if(NOT CMAKE_VERSION VERSION_LESS 3.0)
     add_library(cereal INTERFACE)
     target_include_directories(cereal INTERFACE

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -454,7 +454,7 @@ namespace cereal
       template <class T> inline
       ArchiveType & processImpl(DeferredData<T> const & d)
       {
-        std::function<void(void)> deferment( [=](){ self->process( d.value ); } );
+        std::function<void(void)> deferment( [this, d](){ self->process( d.value ); } );
         itsDeferments.emplace_back( std::move(deferment) );
 
         return *self;
@@ -859,7 +859,7 @@ namespace cereal
       template <class T> inline
       ArchiveType & processImpl(DeferredData<T> const & d)
       {
-        std::function<void(void)> deferment( [=](){ self->process( d.value ); } );
+        std::function<void(void)> deferment( [this, d](){ self->process( d.value ); } );
         itsDeferments.emplace_back( std::move(deferment) );
 
         return *self;

--- a/unittests/doctest.h
+++ b/unittests/doctest.h
@@ -773,34 +773,19 @@ namespace detail {
     // cppcheck-suppress unusedStructMember
     { static const bool value = false; };
 
-    namespace has_insertion_operator_impl {
-        typedef char no;
-        typedef char yes[2];
+    template<typename T>
+    class has_insertion_operator
+    {
+        template<typename TT>
+        static auto test(int)
+        -> decltype( std::declval<std::ostream&>() << std::declval<TT>(), std::true_type() );
 
-        struct any_t
-        {
-            template <typename T>
-            // cppcheck-suppress noExplicitConstructor
-            any_t(const DOCTEST_REF_WRAP(T));
-        };
+        template<typename>
+        static auto test(...) -> std::false_type;
 
-        yes& testStreamable(std::ostream&);
-        no   testStreamable(no);
-
-        no operator<<(const std::ostream&, const any_t&);
-
-        template <typename T>
-        struct has_insertion_operator
-        {
-            static std::ostream& s;
-            static const DOCTEST_REF_WRAP(T) t;
-            static const bool value = sizeof(decltype(testStreamable(s << t))) == sizeof(yes);
-        };
-    } // namespace has_insertion_operator_impl
-
-    template <typename T>
-    struct has_insertion_operator : has_insertion_operator_impl::has_insertion_operator<T>
-    {};
+    public:
+        static const bool value = decltype(test<T>(0))::value;
+    };
 
     DOCTEST_INTERFACE void my_memcpy(void* dest, const void* src, unsigned num);
 


### PR DESCRIPTION
This is possible solution to problem outlined in issue #638 
Tested on `g++-10 (Ubuntu 10-20200416-0ubuntu1~18.04) 10.0.1 20200416 (experimental) [master revision 3c3f12e2a76:dcee354ce56:44b326839d864fc10c459916abcc97f35a9ac3de]` , `c++ (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0` and `g++ (GCC) 9.3.0` with `cmake -DSKIP_PORTABILITY_TEST=ON` 