### PR TITLE
[cpp20] explicitly capture 'this' as copy

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -454,7 +454,7 @@ namespace cereal
       template <class T> inline
       ArchiveType & processImpl(DeferredData<T> const & d)
       {
-        std::function<void(void)> deferment( [=](){ self->process( d.value ); } );
+        std::function<void(void)> deferment( [this, d](){ self->process( d.value ); } );
         itsDeferments.emplace_back( std::move(deferment) );
 
         return *self;
@@ -859,7 +859,7 @@ namespace cereal
       template <class T> inline
       ArchiveType & processImpl(DeferredData<T> const & d)
       {
-        std::function<void(void)> deferment( [=](){ self->process( d.value ); } );
+        std::function<void(void)> deferment( [this, d](){ self->process( d.value ); } );
         itsDeferments.emplace_back( std::move(deferment) );
 
         return *self;


### PR DESCRIPTION
separate PR for lambda captures created as requested in #639 