### PR TITLE
Fixes to prevent clang-diagnostic errors

### DIFF
--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -654,7 +654,7 @@ namespace cereal
 
             auto ptr = PolymorphicCasters::template downcast<T>( dptr, baseInfo );
 
-            #ifdef _MSC_VER
+            #if defined(_MSC_VER) & !defined(__clang__)
             savePolymorphicSharedPtr( ar, ptr, ::cereal::traits::has_shared_from_this<T>::type() ); // MSVC doesn't like typename here
             #else // not _MSC_VER
             savePolymorphicSharedPtr( ar, ptr, typename ::cereal::traits::has_shared_from_this<T>::type() );

--- a/include/cereal/details/polymorphic_impl.hpp
+++ b/include/cereal/details/polymorphic_impl.hpp
@@ -654,7 +654,7 @@ namespace cereal
 
             auto ptr = PolymorphicCasters::template downcast<T>( dptr, baseInfo );
 
-            #if defined(_MSC_VER) & !defined(__clang__)
+            #if defined(_MSC_VER) && !defined(__clang__)
             savePolymorphicSharedPtr( ar, ptr, ::cereal::traits::has_shared_from_this<T>::type() ); // MSVC doesn't like typename here
             #else // not _MSC_VER
             savePolymorphicSharedPtr( ar, ptr, typename ::cereal::traits::has_shared_from_this<T>::type() );

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -44,7 +44,7 @@
     License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt) */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) & !defined(__clang__)
 #   define CEREAL_DLL_EXPORT __declspec(dllexport)
 #   define CEREAL_USED
 #else // clang or gcc

--- a/include/cereal/details/static_object.hpp
+++ b/include/cereal/details/static_object.hpp
@@ -44,7 +44,7 @@
     License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
     http://www.boost.org/LICENSE_1_0.txt) */
 
-#if defined(_MSC_VER) & !defined(__clang__)
+#if defined(_MSC_VER) && !defined(__clang__)
 #   define CEREAL_DLL_EXPORT __declspec(dllexport)
 #   define CEREAL_USED
 #else // clang or gcc


### PR DESCRIPTION
When building projects with Visual Studio and cmake and in addition using clang-tidy we see clang-diagnostic errors in the cereal codebase during the clang-tidy execution.  The binaries are built using the msvc compiler (visual studio 16.6.0, Microsoft (R) C/C++ Optimizing Compiler Version 19.26.28805 for x64), successfully.  clang-tidy uses the llvm tool chain and thus the clang compiler (version 9.0.0).

This scenario occurs during the clang-tidy run.  clang-tidy is executed using the build commands generated by cmake, as such _MSC_VER is defined even though the clang compiler is being utilised.

The following diagnostics are generated during the clang-tidy run:

C:\Src\****************\out\build\Windows-x64-Debug\_deps\cereal-src\package\include\cereal\details\static_object.hpp(67,29): error G70D0A859: 'cereal::detail::StaticObject<cereal::detail::bind_to_archives<datapath::udp_stream::send_session_configuration, cereal::detail::(anonymous namespace)::polymorphic_binding_tag> >' must have external linkage when declared 'dllexport' [clang-diagnostic-error]
      class CEREAL_DLL_EXPORT StaticObject
                              ^


And...

C:\Src\******************\out\build\Windows-x64-Debug\_deps\cereal-src\package\include\cereal\details\polymorphic_impl.hpp(658,91): error GD8FB81D5: unexpected type name 'type': expected expression [clang-diagnostic-error]
              savePolymorphicSharedPtr( ar, ptr, ::cereal::traits::has_shared_from_this<T>::type() ); // MSVC doesn't like typename here
......

A guard is required to prevent the un-versioned _MSC_VER test from being taken when compiling with clang under these circumstances.  The clang compiler identifies itself using the __clang__ pre-defined macro which can be used to provide a guard.
