### PR TITLE
Add Bazel build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 *.idb
 *\build_*
 
+# Bazel build output
+/bazel-*
+
 # misc files mostly used for testing
 out.txt
 ptr.txt

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,6 @@
+cc_library(
+    name = "cereal",
+    hdrs = glob(["include/cereal/**/*.hpp"]),
+    strip_include_prefix = "include/",
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
This PR adds a Bazel build file for cereal headers.

For example, if we put the code sample from the cereal README in a file called `my_program.cc` and add the Bazel rule 
```
cc_binary(
    name = "my_program",
    srcs = ["my_program.cc"],
    deps = ["//:cereal"],
)
```
then the code sample compiles.