### PR TITLE
Added JSONInputArchive constructor from an already parsed rapidjson::Document

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -434,14 +434,21 @@ namespace cereal
       /*! @param stream The stream to read from */
       JSONInputArchive(std::istream & stream) :
         InputArchive<JSONInputArchive>(this),
-        itsNextName( nullptr ),
-        itsReadStream(stream)
+        itsNextName( nullptr )
       {
+        ReadStream itsReadStream(stream);
         itsDocument.ParseStream<>(itsReadStream);
-        if (itsDocument.IsArray())
-          itsIteratorStack.emplace_back(itsDocument.Begin(), itsDocument.End());
-        else
-          itsIteratorStack.emplace_back(itsDocument.MemberBegin(), itsDocument.MemberEnd());
+        initNodes();
+      }
+
+      //! Construct, using the provided JSON document
+      /*! @param doc The JSON document to use */
+      JSONInputArchive(CEREAL_RAPIDJSON_NAMESPACE::Document doc) :
+          InputArchive<JSONInputArchive>(this),
+          itsNextName( nullptr ),
+          itsDocument(std::move(doc))
+      {
+        initNodes();
       }
 
       ~JSONInputArchive() CEREAL_NOEXCEPT = default;
@@ -573,6 +580,15 @@ namespace cereal
         }
 
         itsNextName = nullptr;
+      }
+
+      //! Starts a root node, going into its proper iterator
+      void initNodes()
+      {
+        if (itsDocument.IsArray())
+          itsIteratorStack.emplace_back(itsDocument.Begin(), itsDocument.End());
+        else
+          itsIteratorStack.emplace_back(itsDocument.MemberBegin(), itsDocument.MemberEnd());
       }
 
     public:
@@ -730,7 +746,6 @@ namespace cereal
 
     private:
       const char * itsNextName;               //!< Next name set by NVP
-      ReadStream itsReadStream;               //!< Rapidjson write stream
       std::vector<Iterator> itsIteratorStack; //!< 'Stack' of rapidJSON iterators
       CEREAL_RAPIDJSON_NAMESPACE::Document itsDocument; //!< Rapidjson document
   };

--- a/unittests/common.hpp
+++ b/unittests/common.hpp
@@ -240,4 +240,22 @@ struct StructHash {
     }
 };
 
+class JSONDocumentWrapper {
+  public:
+    JSONDocumentWrapper(const std::string & string)
+    {
+      std::istringstream stream(string);
+      CEREAL_RAPIDJSON_NAMESPACE::IStreamWrapper readStream(stream);
+      document.ParseStream<>(readStream);
+    }
+
+    operator CEREAL_RAPIDJSON_NAMESPACE::Document ()
+    {
+      return std::move(document);
+    }
+
+  private:
+    CEREAL_RAPIDJSON_NAMESPACE::Document document;
+};
+
 #endif // CEREAL_TEST_COMMON_H_

--- a/unittests/map.cpp
+++ b/unittests/map.cpp
@@ -49,6 +49,11 @@ TEST_CASE("json_map")
   test_map<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+TEST_CASE("json_document_map")
+{
+  test_map<cereal::JSONInputArchive, cereal::JSONOutputArchive, JSONDocumentWrapper>();
+}
+
 TEST_CASE("binary_map_memory")
 {
   test_map_memory<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
@@ -67,6 +72,11 @@ TEST_CASE("xml_map_memory")
 TEST_CASE("json_map_memory")
 {
   test_map_memory<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+TEST_CASE("json_document_map_memory")
+{
+  test_map_memory<cereal::JSONInputArchive, cereal::JSONOutputArchive, JSONDocumentWrapper>();
 }
 
 TEST_SUITE_END();

--- a/unittests/map.hpp
+++ b/unittests/map.hpp
@@ -28,7 +28,7 @@
 #define CEREAL_TEST_MAP_H_
 #include "common.hpp"
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, class IStream = std::istringstream> inline
 void test_map()
 {
   std::random_device rd;
@@ -83,7 +83,7 @@ void test_map()
     std::map<uint32_t, StructExternalSerialize> i_esermap;
     std::map<int8_t, StructExternalSplit>       i_esplmap;
 
-    std::istringstream is(os.str());
+    IStream is(os.str());
     {
       IArchive iar(is);
 
@@ -112,7 +112,7 @@ void test_map()
   }
 }
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, class IStream = std::istringstream> inline
 void test_map_memory()
 {
   std::random_device rd;
@@ -145,7 +145,7 @@ void test_map_memory()
     decltype( o_uniqueptrMap ) i_uniqueptrMap;
     decltype( o_sharedptrMap ) i_sharedptrMap;
 
-    std::istringstream is(os.str());
+    IStream is(os.str());
     {
       IArchive iar(is);
 

--- a/unittests/pod.cpp
+++ b/unittests/pod.cpp
@@ -49,4 +49,9 @@ TEST_CASE("json_pod")
   test_pod<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+TEST_CASE("json_document_pod")
+{
+  test_pod<cereal::JSONInputArchive, cereal::JSONOutputArchive, JSONDocumentWrapper>();
+}
+
 TEST_SUITE_END();

--- a/unittests/pod.hpp
+++ b/unittests/pod.hpp
@@ -28,7 +28,7 @@
 #define CEREAL_TEST_POD_H_
 #include "common.hpp"
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, class IStream = std::istringstream> inline
 void test_pod()
 {
   std::random_device rd;
@@ -99,7 +99,7 @@ void test_pod()
     long long i_long_long           = 0;
     unsigned long long i_ulong_long = 0;
 
-    std::istringstream is(os.str());
+    IStream is(os.str());
     {
       IArchive iar(is);
       iar(i_bool);

--- a/unittests/structs_specialized.cpp
+++ b/unittests/structs_specialized.cpp
@@ -49,4 +49,9 @@ TEST_CASE("json_structs_specialized")
   test_structs_specialized<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+TEST_CASE("json_document_structs_specialized")
+{
+  test_structs_specialized<cereal::JSONInputArchive, cereal::JSONOutputArchive, JSONDocumentWrapper>();
+}
+
 TEST_SUITE_END();

--- a/unittests/structs_specialized.hpp
+++ b/unittests/structs_specialized.hpp
@@ -366,7 +366,7 @@ namespace cereal
 CEREAL_REGISTER_TYPE(SpecializedMSplitPolymorphic)
 CEREAL_REGISTER_POLYMORPHIC_RELATION(BogusBasePolymorphic, SpecializedMSplitPolymorphic)
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, class IStream = std::istringstream> inline
 void test_structs_specialized()
 {
   std::random_device rd;
@@ -428,7 +428,7 @@ void test_structs_specialized()
     decltype(o_esplm) i_esplm;
     decltype(o_esplvm) i_esplvm;
 
-    std::istringstream is(os.str());
+    IStream is(os.str());
     {
       IArchive iar(is);
 

--- a/unittests/vector.cpp
+++ b/unittests/vector.cpp
@@ -49,4 +49,9 @@ TEST_CASE("json_vector")
   test_vector<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
 }
 
+TEST_CASE("json_document_vector")
+{
+  test_vector<cereal::JSONInputArchive, cereal::JSONOutputArchive, JSONDocumentWrapper>();
+}
+
 TEST_SUITE_END();

--- a/unittests/vector.hpp
+++ b/unittests/vector.hpp
@@ -28,7 +28,7 @@
 #define CEREAL_TEST_VECTOR_H_
 #include "common.hpp"
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, class IStream = std::istringstream> inline
 void test_vector()
 {
   std::random_device rd;
@@ -79,7 +79,7 @@ void test_vector()
     std::vector<StructExternalSerialize> i_eservector;
     std::vector<StructExternalSplit>     i_esplvector;
 
-    std::istringstream is(os.str());
+    IStream is(os.str());
     {
       IArchive iar(is);
 


### PR DESCRIPTION
Hi,
And thanks for a great library!

I've got the following problem.
```cpp
std::string jsonStr;
rapidjson::Document doc;
doc.Parse(jsonStr.data());

if (doc["type"].GetString() == "foo") {  // "type" field can't be renamed
    Foo foo{};
    {
        std::istringstream input{jsonStr};
        cereal::JSONInputArchive archive{input};  // creates a new Document and parses the string again!
        serialize(archive, foo);
    }
    applyStaticallyTypedCallback(foo);

} else if (doc["type"].GetString() == "bar") {
    Bar bar{};
    // etc.
}
```

I'm aware that some similar (de)serializing could be done with the built-in Polymorphic Types feature, but it uses its own internal fields like "polymorphic_name" and "polymorphic_id", whose names are hardcoded, and the code around them seems not so easy to intervene and customize.

I propose to allow constructing JSONInputArchive via move-from an already parsed rapidjson::Document to fix at least the performance issues of this case.