### PR TITLE
Adding ability to detect a RapidJSON parse error in JSONInputArchive

### DIFF
--- a/sandbox/sandbox_json.cpp
+++ b/sandbox/sandbox_json.cpp
@@ -442,5 +442,21 @@ int main()
     std::cout << (ull == std::numeric_limits<unsigned long long>::max()) << std::endl;
   }
 
+  // test parse error
+  std::stringstream errstr;
+  {
+    std::cout << "---------------------" << std::endl;
+    cereal::JSONInputArchive ar(errstr, true);
+    std::cout << ar.hasParseError() << std::endl;
+    if (ar)
+    {
+      std::cout << "fail" << std::endl;
+    }
+    else
+    {
+      std::cout << "success" << std::endl;
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
For my application, I'd like to show an error message when attempting to open a JSONInputArchive on a malformed, or otherwise erroneous json file.

This additional, optional parameter in JSONInputArchive's constructor will allow me to prevent cereal from thworing a RapidJSON exception, and will instead allow me to simply show the user an error message.

This PR is not meant to do anything more than simply expose the RapidJSON document's HasParseError() value