### PR TITLE
cleanup cmake files to be a little more moderen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,13 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE li
 endif()
 
 
-set(CEREAL_THREAD_LIBS "")
+set(CEREAL_THREAD_LIBS)
 if(UNIX)
     option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
     if(THREAD_SAFE)
         message(STATUS "Use mutexes")
         add_definitions(-DCEREAL_THREAD_SAFE=1)
-        set(CEREAL_THREAD_LIBS "pthread")
+        set(CEREAL_THREAD_LIBS pthread)
     endif()
 endif()
 
@@ -61,7 +61,7 @@ target_include_directories(cereal INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-list(APPEND CEREAL_THREAD_LIBS "cereal::cereal")
+list(APPEND CEREAL_THREAD_LIBS cereal::cereal)
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.8)
     target_compile_features(cereal INTERFACE cxx_std_11)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,14 +19,13 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE li
 endif()
 
 
+set(CEREAL_THREAD_LIBS "")
 if(UNIX)
     option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
     if(THREAD_SAFE)
         message(STATUS "Use mutexes")
         add_definitions(-DCEREAL_THREAD_SAFE=1)
         set(CEREAL_THREAD_LIBS "pthread")
-    else()
-        set(CEREAL_THREAD_LIBS "")
     endif()
 endif()
 
@@ -48,21 +47,11 @@ else()
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
     endif()
 
-    # TODO: should not be needed! CK
-    # if(CMAKE_VERSION VERSION_LESS 3.1)
-    #     set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-    # else()
-        if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD STREQUAL "98")
-            set(CMAKE_CXX_STANDARD 11)
-        endif()
+    if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD STREQUAL "98")
+        set(CMAKE_CXX_STANDARD 11)
+    endif()
 
-        # XXX Why should we needed this? CK
-        # if(CMAKE_CXX_STANDARD GREATER 14)
-        #     cmake_policy(VERSION 3.8)
-        # endif()
-
-        set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    # endif()
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
 
@@ -74,30 +63,44 @@ target_include_directories(cereal INTERFACE
 )
 list(APPEND CEREAL_THREAD_LIBS "cereal::cereal")
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+if(NOT CMAKE_VERSION VERSION_LESS 3.8)
     target_compile_features(cereal INTERFACE cxx_std_11)
 endif()
 
+
 option(CEREAL_INSTALL "Generate the install target" ${CEREAL_MASTER_PROJECT})
 if(CEREAL_INSTALL)
-    install(TARGETS cereal EXPORT cereal
-        DESTINATION lib) # ignored
-    install(EXPORT cereal FILE cereal-config.cmake
-        NAMESPACE "cereal::"
-        DESTINATION lib/cmake/cereal)
+    include(CMakePackageConfigHelpers)
+
+    install(TARGETS cereal EXPORT ${PROJECT_NAME}Targets)
     install(DIRECTORY include/cereal DESTINATION include)
+
+    set(configFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake)
+    set(versionFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake)
+    set(configInstallDestination lib/cmake/${PROJECT_NAME})
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+        ${configFile}
+        INSTALL_DESTINATION ${configInstallDestination}
+    )
+    write_basic_package_version_file(
+        ${versionFile}
+        COMPATIBILITY SameMajorVersion
+    )
+
+    install(FILES ${configFile} ${versionFile} DESTINATION ${configInstallDestination})
+    install(
+        EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE "cereal::"
+        DESTINATION ${configInstallDestination}
+    )
 endif()
 
 
 if(JUST_INSTALL_CEREAL)
     return()
 endif()
-
-
-# TODO: should not be needed! CK
-# if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-#     cmake_policy(VERSION 3.12)
-# endif()
 
 
 if(NOT SKIP_PERFORMANCE_COMPARISON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6...3.15)
 
-project(cereal LANGUAGES CXX)
+project(cereal LANGUAGES CXX VERSION 1.3.0)
 
 if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CEREAL_MASTER_PROJECT ON)
@@ -44,7 +44,7 @@ else()
     if(APPLE OR CLANG_USE_LIBCPP)
         message(STATUS "Use libc++")
         add_compile_options(-stdlib=libc++)
-        # TODO: use add_link_options(-stdlib=libc++ -lc++abi") bud needs cmake 3.13! CK
+        # TODO: use add_link_options(-stdlib=libc++ -lc++abi") bud this needs cmake 3.13! CK
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
     endif()
 
@@ -56,7 +56,7 @@ else()
             set(CMAKE_CXX_STANDARD 11)
         endif()
 
-        # XXX Why should this needed? CK
+        # XXX Why should we needed this? CK
         # if(CMAKE_CXX_STANDARD GREATER 14)
         #     cmake_policy(VERSION 3.8)
         # endif()
@@ -66,27 +66,27 @@ else()
 endif()
 
 
-# TODO: should not be needed! CK
-# if(NOT CMAKE_VERSION VERSION_LESS 3.0)
-    add_library(cereal INTERFACE)
-    add_library(cereal::cereal ALIAS cereal)
-    target_compile_features(cereal INTERFACE cxx_std_11)
-    target_include_directories(cereal INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-    )
-    list(APPEND CEREAL_THREAD_LIBS "cereal::cereal")
+add_library(cereal INTERFACE)
+add_library(cereal::cereal ALIAS cereal)
+target_include_directories(cereal INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+list(APPEND CEREAL_THREAD_LIBS "cereal::cereal")
 
-    option(CEREAL_INSTALL "Generate the install target" ${CEREAL_MASTER_PROJECT})
-    if(CEREAL_INSTALL)
-        install(TARGETS cereal EXPORT cereal
-            DESTINATION lib) # ignored
-        install(EXPORT cereal FILE cereal-config.cmake
-            NAMESPACE "cereal::"
-            DESTINATION lib/cmake/cereal)
-        install(DIRECTORY include/cereal DESTINATION include)
-    endif()
-# endif()
+if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+    target_compile_features(cereal INTERFACE cxx_std_11)
+endif()
+
+option(CEREAL_INSTALL "Generate the install target" ${CEREAL_MASTER_PROJECT})
+if(CEREAL_INSTALL)
+    install(TARGETS cereal EXPORT cereal
+        DESTINATION lib) # ignored
+    install(EXPORT cereal FILE cereal-config.cmake
+        NAMESPACE "cereal::"
+        DESTINATION lib/cmake/cereal)
+    install(DIRECTORY include/cereal DESTINATION include)
+endif()
 
 
 if(JUST_INSTALL_CEREAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8...3.15)
+cmake_minimum_required(VERSION 3.6...3.15)
 
 project(cereal LANGUAGES CXX)
 
@@ -95,7 +95,7 @@ endif()
 
 if(NOT SKIP_PERFORMANCE_COMPARISON)
     # Boost serialization for performance sandbox
-    find_package(Boost COMPONENTS serialization)
+    find_package(Boost REQUIRED COMPONENTS serialization)
 
     # TODO: should not be needed! CK
     if(Boost_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,9 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
 endif()
 
 
-option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" OFF)
+if(APPLE)
+    option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" ON)
+endif()
 option(SKIP_PERFORMANCE_COMPARISON "Skip building performance comparison (requires boost)" OFF)
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE lib
@@ -16,10 +18,13 @@ endif()
 
 
 if(UNIX)
-    option(THREAD_SAFE "Use mutexes to ensure thread safety" ON)
+    option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
     if(THREAD_SAFE)
+        message(WARNING "use mutexes")
         add_definitions(-DCEREAL_THREAD_SAFE=1)
         set(CEREAL_THREAD_LIBS "pthread")
+    else()
+        set(CEREAL_THREAD_LIBS "")
     endif()
 endif()
 
@@ -27,14 +32,15 @@ endif()
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /W3 /WX")
 else()
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wshadow -Wold-style-cast ${CMAKE_CXX_FLAGS}")
     option(WITH_WERROR "Compile with '-Werror' C++ compiler flag" ON)
     if(WITH_WERROR)
         set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
     endif()
 
-    option(CLANG_USE_LIBCPP "Use libc++ for clang compilation" ON)
-    if(CLANG_USE_LIBCPP)
+    option(CLANG_USE_LIBCPP "Use libc++ for clang compilation" OFF)
+    if(APPLE OR CLANG_USE_LIBCPP)
+        message(WARNING "use libc++")
         set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
     endif()
@@ -80,7 +86,8 @@ if(JUST_INSTALL_CEREAL)
     return()
 endif()
 
-#XXX include_directories(SYSTEM ./include)
+# TODO: should not be needed! CK
+include_directories(SYSTEM ./include)
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.12)
     cmake_policy(VERSION 3.12)
@@ -90,9 +97,10 @@ if(NOT SKIP_PERFORMANCE_COMPARISON)
     # Boost serialization for performance sandbox
     find_package(Boost COMPONENTS serialization)
 
-# if(Boost_FOUND)
-#XXX  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-# endif()
+    # TODO: should not be needed! CK
+    if(Boost_FOUND)
+        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,10 @@ endif()
 if(APPLE)
     option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" ON)
 endif()
+
 option(SKIP_PERFORMANCE_COMPARISON "Skip building performance comparison (requires boost)" OFF)
 
+# TODO: should not be needed! CK
 if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE lib
     option(JUST_INSTALL_CEREAL "Don't do anything besides installing the library" OFF)
 endif()
@@ -20,7 +22,7 @@ endif()
 if(UNIX)
     option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
     if(THREAD_SAFE)
-        message(WARNING "use mutexes")
+        message(STATUS "Use mutexes")
         add_definitions(-DCEREAL_THREAD_SAFE=1)
         set(CEREAL_THREAD_LIBS "pthread")
     else()
@@ -30,40 +32,45 @@ endif()
 
 
 if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /W3 /WX")
+    add_compile_options(/bigobj /W3 /WX)
 else()
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wshadow -Wold-style-cast ${CMAKE_CXX_FLAGS}")
+    add_compile_options(-Wall -Wextra -pedantic -Wshadow -Wold-style-cast)
     option(WITH_WERROR "Compile with '-Werror' C++ compiler flag" ON)
     if(WITH_WERROR)
-        set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
+        add_compile_options(-Werror)
     endif()
 
     option(CLANG_USE_LIBCPP "Use libc++ for clang compilation" OFF)
     if(APPLE OR CLANG_USE_LIBCPP)
-        message(WARNING "use libc++")
-        set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
+        message(STATUS "Use libc++")
+        add_compile_options(-stdlib=libc++)
+        # TODO: use add_link_options(-stdlib=libc++ -lc++abi") bud needs cmake 3.13! CK
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
     endif()
 
-    if(CMAKE_VERSION VERSION_LESS 3.1)
-        set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
-    else()
+    # TODO: should not be needed! CK
+    # if(CMAKE_VERSION VERSION_LESS 3.1)
+    #     set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+    # else()
         if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD STREQUAL "98")
             set(CMAKE_CXX_STANDARD 11)
         endif()
 
-        if(CMAKE_CXX_STANDARD GREATER 14)
-            cmake_minimum_required(VERSION 3.8)
-        endif()
+        # XXX Why should this needed? CK
+        # if(CMAKE_CXX_STANDARD GREATER 14)
+        #     cmake_policy(VERSION 3.8)
+        # endif()
 
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    endif()
+    # endif()
 endif()
 
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.0)
+# TODO: should not be needed! CK
+# if(NOT CMAKE_VERSION VERSION_LESS 3.0)
     add_library(cereal INTERFACE)
     add_library(cereal::cereal ALIAS cereal)
+    target_compile_features(cereal INTERFACE cxx_std_11)
     target_include_directories(cereal INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
@@ -79,28 +86,23 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.0)
             DESTINATION lib/cmake/cereal)
         install(DIRECTORY include/cereal DESTINATION include)
     endif()
-endif()
+# endif()
 
 
 if(JUST_INSTALL_CEREAL)
     return()
 endif()
 
-# TODO: should not be needed! CK
-include_directories(SYSTEM ./include)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-    cmake_policy(VERSION 3.12)
-endif()
+# TODO: should not be needed! CK
+# if(NOT CMAKE_VERSION VERSION_LESS 3.12)
+#     cmake_policy(VERSION 3.12)
+# endif()
+
 
 if(NOT SKIP_PERFORMANCE_COMPARISON)
     # Boost serialization for performance sandbox
     find_package(Boost REQUIRED COMPONENTS serialization)
-
-    # TODO: should not be needed! CK
-    if(Boost_FOUND)
-        include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-    endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,30 +1,39 @@
-cmake_minimum_required (VERSION 2.6.2)
-project (cereal)
+cmake_minimum_required(VERSION 3.8...3.15)
+
+project(cereal LANGUAGES CXX)
+
+if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CEREAL_MASTER_PROJECT ON)
+endif()
+
 
 option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" OFF)
 option(SKIP_PERFORMANCE_COMPARISON "Skip building performance comparison (requires boost)" OFF)
+
 if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE lib
     option(JUST_INSTALL_CEREAL "Don't do anything besides installing the library" OFF)
 endif()
 
-option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
-if(THREAD_SAFE)
-    add_definitions(-DCEREAL_THREAD_SAFE=1)
-    set(CEREAL_THREAD_LIBS "pthread")
-else()
-    set(CEREAL_THREAD_LIBS "")
+
+if(UNIX)
+    option(THREAD_SAFE "Use mutexes to ensure thread safety" ON)
+    if(THREAD_SAFE)
+        add_definitions(-DCEREAL_THREAD_SAFE=1)
+        set(CEREAL_THREAD_LIBS "pthread")
+    endif()
 endif()
+
 
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /W3 /WX")
 else()
-    set(CMAKE_CXX_FLAGS "-Wall -g -Wextra -Wshadow -pedantic -Wold-style-cast ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wold-style-cast ${CMAKE_CXX_FLAGS}")
     option(WITH_WERROR "Compile with '-Werror' C++ compiler flag" ON)
     if(WITH_WERROR)
         set(CMAKE_CXX_FLAGS "-Werror ${CMAKE_CXX_FLAGS}")
-    endif(WITH_WERROR)
+    endif()
 
-    option(CLANG_USE_LIBCPP "Use libc++ for clang compilation" OFF)
+    option(CLANG_USE_LIBCPP "Use libc++ for clang compilation" ON)
     if(CLANG_USE_LIBCPP)
         set(CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
@@ -33,51 +42,65 @@ else()
     if(CMAKE_VERSION VERSION_LESS 3.1)
         set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
     else()
-      if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD STREQUAL "98")
-        set(CMAKE_CXX_STANDARD 11)
-      endif()
+        if(NOT DEFINED CMAKE_CXX_STANDARD OR CMAKE_CXX_STANDARD STREQUAL "98")
+            set(CMAKE_CXX_STANDARD 11)
+        endif()
 
-      if(CMAKE_CXX_STANDARD GREATER 14)
-        cmake_minimum_required(VERSION 3.8)
-      endif()
+        if(CMAKE_CXX_STANDARD GREATER 14)
+            cmake_minimum_required(VERSION 3.8)
+        endif()
 
-      set(CMAKE_CXX_STANDARD_REQUIRED ON)
+        set(CMAKE_CXX_STANDARD_REQUIRED ON)
     endif()
-
 endif()
+
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.0)
     add_library(cereal INTERFACE)
+    add_library(cereal::cereal ALIAS cereal)
     target_include_directories(cereal INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
     )
-    install(TARGETS cereal EXPORT cereal
-        DESTINATION lib) # ignored
-    install(EXPORT cereal FILE cereal-config.cmake
-        DESTINATION share/cmake/cereal)
-    install(DIRECTORY include/cereal DESTINATION include)
+    list(APPEND CEREAL_THREAD_LIBS "cereal::cereal")
+
+    option(CEREAL_INSTALL "Generate the install target" ${CEREAL_MASTER_PROJECT})
+    if(CEREAL_INSTALL)
+        install(TARGETS cereal EXPORT cereal
+            DESTINATION lib) # ignored
+        install(EXPORT cereal FILE cereal-config.cmake
+            NAMESPACE "cereal::"
+            DESTINATION lib/cmake/cereal)
+        install(DIRECTORY include/cereal DESTINATION include)
+    endif()
 endif()
+
 
 if(JUST_INSTALL_CEREAL)
     return()
 endif()
 
-include_directories(./include)
+#XXX include_directories(SYSTEM ./include)
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.12)
-  cmake_policy(VERSION 3.12)
+    cmake_policy(VERSION 3.12)
 endif()
 
-# Boost serialization for performance sandbox
-find_package(Boost COMPONENTS serialization)
+if(NOT SKIP_PERFORMANCE_COMPARISON)
+    # Boost serialization for performance sandbox
+    find_package(Boost COMPONENTS serialization)
 
-if(Boost_FOUND)
-  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-endif(Boost_FOUND)
-  
-enable_testing()
-add_subdirectory(unittests)
+# if(Boost_FOUND)
+#XXX  include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+# endif()
+endif()
+
+
+option(BUILD_TESTS "Build tests" ${CEREAL_MASTER_PROJECT})
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(unittests)
+endif()
 
 add_subdirectory(sandbox)
 

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -15,4 +15,4 @@ if(DOXYGEN_FOUND)
     COMMENT "Copying documentation to gh-pages branch" VERBATIM
     )
 
-endif(DOXYGEN_FOUND)
+endif()

--- a/sandbox/CMakeLists.txt
+++ b/sandbox/CMakeLists.txt
@@ -1,17 +1,22 @@
 add_subdirectory(sandbox_shared_lib)
 
 add_executable(sandbox sandbox.cpp)
+target_link_libraries(sandbox ${CEREAL_THREAD_LIBS})
+
 add_executable(sandbox_json sandbox_json.cpp)
+target_link_libraries(sandbox_json ${CEREAL_THREAD_LIBS})
+
 add_executable(sandbox_rtti sandbox_rtti.cpp)
+target_link_libraries(sandbox_rtti ${CEREAL_THREAD_LIBS})
 
 add_executable(sandbox_vs sandbox_vs.cpp)
 target_link_libraries(sandbox_vs sandbox_vs_dll)
-include_directories(sandbox_shared_lib)
 
-if((Boost_FOUND) AND NOT SKIP_PERFORMANCE_COMPARISON)
+if(Boost_FOUND AND NOT SKIP_PERFORMANCE_COMPARISON)
   add_executable(performance performance.cpp)
   if(MSVC)
     set_target_properties(performance PROPERTIES COMPILE_DEFINITIONS "BOOST_SERIALIZATION_DYN_LINK")
   endif()
-  target_link_libraries(performance ${Boost_LIBRARIES})
+  target_include_directories(performance PUBLIC ${Boost_INCLUDE_DIRS})
+  target_link_libraries(performance ${CEREAL_THREAD_LIBS} ${Boost_LIBRARIES})
 endif()

--- a/sandbox/sandbox_shared_lib/CMakeLists.txt
+++ b/sandbox/sandbox_shared_lib/CMakeLists.txt
@@ -1,1 +1,6 @@
 add_library(sandbox_vs_dll SHARED base.cpp derived.cpp)
+target_link_libraries(sandbox_vs_dll ${CEREAL_THREAD_LIBS})
+target_include_directories(sandbox_vs_dll PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:include>
+)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -52,6 +52,7 @@ foreach(TEST_SOURCE ${TESTS})
       add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
       set_target_properties(${TEST_TARGET}_32 PROPERTIES
         COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
+      target_link_libraries(${TEST_TARGET}_32 ${CEREAL_THREAD_LIBS})
       add_test(NAME "${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
     endif()
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
-# A semi-colon separated list of test sources that should not be automatically built with doctest 
+# A semi-colon separated list of test sources that should not be automatically built with doctest
 set(SPECIAL_TESTS "portability_test.cpp")
 
 if(CMAKE_VERSION VERSION_LESS 2.8)
@@ -13,11 +13,13 @@ if(NOT SKIP_PORTABILITY_TEST)
   if((${CMAKE_SIZEOF_VOID_P} EQUAL 8))
     if(NOT MSVC)
       add_executable(portability_test32 portability_test.cpp)
+      target_link_libraries(portability_test32 ${CEREAL_THREAD_LIBS})
       set_target_properties(portability_test32 PROPERTIES COMPILE_FLAGS "-m32")
       set_target_properties(portability_test32 PROPERTIES LINK_FLAGS "-m32")
     endif()
 
     add_executable(portability_test64 portability_test.cpp)
+    target_link_libraries(portability_test64 ${CEREAL_THREAD_LIBS})
 
     add_test(NAME portability_test
             COMMAND ${CMAKE_COMMAND}
@@ -26,6 +28,7 @@ if(NOT SKIP_PORTABILITY_TEST)
 
   elseif(MSVC)
     add_executable(portability_test32 portability_test.cpp)
+    target_link_libraries(portability_test32 cereal::cereal)
   endif()
 endif()
 
@@ -42,14 +45,14 @@ foreach(TEST_SOURCE ${TESTS})
 
     add_executable(${TEST_TARGET} ${TEST_SOURCE})
     target_link_libraries(${TEST_TARGET} ${CEREAL_THREAD_LIBS})
-    add_test("${TEST_TARGET}" "${TEST_TARGET}")
+    add_test(NAME "${TEST_TARGET}" COMMAND "${TEST_TARGET}")
 
     # If we are on a 64-bit machine, create an extra 32-bit version of the test if portability testing is enabled
     if((NOT MSVC) AND (${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
       add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
       set_target_properties(${TEST_TARGET}_32 PROPERTIES
         COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
-      add_test("${TEST_TARGET}_32" "${TEST_TARGET}_32")
+      add_test(NAME "${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
     endif()
 
   endif()
@@ -85,7 +88,7 @@ if(NOT MSVC)
       target_link_libraries(${COVERAGE_TARGET} ${CEREAL_THREAD_LIBS})
     endif()
   endforeach()
-endif(NOT MSVC)
+endif()
 
 if(CMAKE_CXX_STANDARD GREATER 14)
   add_subdirectory(cpp17)
@@ -96,5 +99,5 @@ if(Boost_FOUND)
 endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.0)
-  add_test(test_cmake_config_module ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake-config-module.cmake)
+  add_test(NAME test_cmake_config_module COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake-config-module.cmake)
 endif()

--- a/unittests/boost/CMakeLists.txt
+++ b/unittests/boost/CMakeLists.txt
@@ -9,14 +9,15 @@ foreach(TEST_SOURCE ${TESTS})
 
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET} ${CEREAL_THREAD_LIBS})
-  add_test("${TEST_TARGET}" "${TEST_TARGET}")
+  add_test("NAME ${TEST_TARGET}" COMMAND "${TEST_TARGET}")
 
   # If we are on a 64-bit machine, create an extra 32-bit version of the test if portability testing is enabled
   if((NOT MSVC) AND (${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
     add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
+    target_link_libraries(${TEST_TARGET}_32 ${CEREAL_THREAD_LIBS})
     set_target_properties(${TEST_TARGET}_32 PROPERTIES
       COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
-    add_test("${TEST_TARGET}_32" "${TEST_TARGET}_32")
+    add_test("NAME ${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
   endif()
 
 endforeach()
@@ -26,7 +27,7 @@ if(NOT MSVC)
   foreach(TEST_SOURCE ${TESTS})
     string(REPLACE ".cpp" "" COVERAGE_TARGET "${TEST_SOURCE}")
     set(COVERAGE_TARGET "coverage_${COVERAGE_TARGET}")
-    
+
     add_dependencies(coverage ${COVERAGE_TARGET})
 
     add_executable(${COVERAGE_TARGET} EXCLUDE_FROM_ALL ${TEST_SOURCE})
@@ -35,4 +36,4 @@ if(NOT MSVC)
     set_target_properties(${COVERAGE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/coverage")
     target_link_libraries(${COVERAGE_TARGET} ${CEREAL_THREAD_LIBS})
   endforeach()
-endif(NOT MSVC)
+endif()

--- a/unittests/boost/CMakeLists.txt
+++ b/unittests/boost/CMakeLists.txt
@@ -9,7 +9,7 @@ foreach(TEST_SOURCE ${TESTS})
 
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET} ${CEREAL_THREAD_LIBS})
-  add_test("NAME ${TEST_TARGET}" COMMAND "${TEST_TARGET}")
+  add_test(NAME "${TEST_TARGET}" COMMAND "${TEST_TARGET}")
 
   # If we are on a 64-bit machine, create an extra 32-bit version of the test if portability testing is enabled
   if((NOT MSVC) AND (${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
@@ -17,7 +17,7 @@ foreach(TEST_SOURCE ${TESTS})
     target_link_libraries(${TEST_TARGET}_32 ${CEREAL_THREAD_LIBS})
     set_target_properties(${TEST_TARGET}_32 PROPERTIES
       COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
-    add_test("NAME ${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
+    add_test(NAME "${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
   endif()
 
 endforeach()

--- a/unittests/boost/CMakeLists.txt
+++ b/unittests/boost/CMakeLists.txt
@@ -1,5 +1,7 @@
 file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+
 # Build all of the non-special tests
 foreach(TEST_SOURCE ${TESTS})
   message(STATUS ${TEST_SOURCE})

--- a/unittests/cmake-config-module.cmake
+++ b/unittests/cmake-config-module.cmake
@@ -2,8 +2,8 @@ if(CMAKE_VERSION LESS 3.0)
   message(FATAL_ERROR "Cereal can't be installed with CMake < 3.0")
 endif()
 
-get_filename_component(BINARY_DIR ${CMAKE_CURRENT_LIST_DIR}/../build ABSOLUTE)
-get_filename_component(INSTALL_DIR ${CMAKE_CURRENT_LIST_DIR}/../out ABSOLUTE)
+get_filename_component(BINARY_DIR ${CMAKE_BINARY_DIR}/build ABSOLUTE)
+get_filename_component(INSTALL_DIR ${CMAKE_BINARY_DIR}/out ABSOLUTE)
 
 # cmake configure step for cereal
 file(MAKE_DIRECTORY ${BINARY_DIR}/cereal)
@@ -44,10 +44,11 @@ file(WRITE ${BINARY_DIR}/test_source/CMakeLists.txt "
   endif()
   find_package(cereal REQUIRED)
   add_executable(cereal-test-config-module main.cpp)
-  target_link_libraries(cereal-test-config-module cereal)
+  target_link_libraries(cereal-test-config-module cereal::cereal)
   enable_testing()
-  add_test(test-cereal-test-config-module cereal-test-config-module)
+  add_test(NAME test-cereal-test-config-module COMMAND cereal-test-config-module)
 ")
+
 file(WRITE ${BINARY_DIR}/test_source/main.cpp "
   #include <cereal/archives/binary.hpp>
   #include <sstream>
@@ -90,6 +91,7 @@ file(WRITE ${BINARY_DIR}/test_source/main.cpp "
     }
   }"
 )
+
 file(MAKE_DIRECTORY ${BINARY_DIR}/test)
 execute_process(
   COMMAND ${CMAKE_COMMAND}

--- a/unittests/cpp17/CMakeLists.txt
+++ b/unittests/cpp17/CMakeLists.txt
@@ -16,7 +16,7 @@ foreach(TEST_SOURCE ${TESTS})
     add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
     set_target_properties(${TEST_TARGET}_32 PROPERTIES
       COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
-    add_test("NAME ${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
+    add_test(NAME "${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
   endif()
 
 endforeach()

--- a/unittests/cpp17/CMakeLists.txt
+++ b/unittests/cpp17/CMakeLists.txt
@@ -9,14 +9,14 @@ foreach(TEST_SOURCE ${TESTS})
 
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET} ${CEREAL_THREAD_LIBS})
-  add_test("${TEST_TARGET}" "${TEST_TARGET}")
+  add_test(NAME "${TEST_TARGET}" COMMAND "${TEST_TARGET}")
 
   # If we are on a 64-bit machine, create an extra 32-bit version of the test if portability testing is enabled
   if((NOT MSVC) AND (${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
     add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
     set_target_properties(${TEST_TARGET}_32 PROPERTIES
       COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
-    add_test("${TEST_TARGET}_32" "${TEST_TARGET}_32")
+    add_test("NAME ${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")
   endif()
 
 endforeach()
@@ -26,7 +26,7 @@ if(NOT MSVC)
   foreach(TEST_SOURCE ${TESTS})
     string(REPLACE ".cpp" "" COVERAGE_TARGET "${TEST_SOURCE}")
     set(COVERAGE_TARGET "coverage_cpp17_${COVERAGE_TARGET}")
-    
+
     add_dependencies(coverage ${COVERAGE_TARGET})
 
     add_executable(${COVERAGE_TARGET} EXCLUDE_FROM_ALL ${TEST_SOURCE})
@@ -35,4 +35,4 @@ if(NOT MSVC)
     set_target_properties(${COVERAGE_TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/coverage")
     target_link_libraries(${COVERAGE_TARGET} ${CEREAL_THREAD_LIBS})
   endforeach()
-endif(NOT MSVC)
+endif()

--- a/unittests/cpp17/CMakeLists.txt
+++ b/unittests/cpp17/CMakeLists.txt
@@ -14,6 +14,7 @@ foreach(TEST_SOURCE ${TESTS})
   # If we are on a 64-bit machine, create an extra 32-bit version of the test if portability testing is enabled
   if((NOT MSVC) AND (${CMAKE_SIZEOF_VOID_P} EQUAL 8) AND (NOT SKIP_PORTABILITY_TEST))
     add_executable(${TEST_TARGET}_32 ${TEST_SOURCE})
+    target_link_libraries(${TEST_TARGET}_32 ${CEREAL_THREAD_LIBS})
     set_target_properties(${TEST_TARGET}_32 PROPERTIES
       COMPILE_FLAGS "-m32" LINK_FLAGS "-m32")
     add_test(NAME "${TEST_TARGET}_32" COMMAND "${TEST_TARGET}_32")


### PR DESCRIPTION
Prepare the use of cereal with add_subdirectory() in a cmake master project.

Use the newer min...max cmake version policy settings feature.

see https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required

Prevent to modify compile and linker FLAGS and to set global includes paths
Keep the source tree free of build artifacts
cmakelint the cmake files too
Handle linker problems on OSX automatically 