### PR TITLE
CVE-2020-11105: Store a copy of each serialized shared_ptr within the archive to prevent the shared_ptr to be freed to early.

### DIFF
--- a/include/cereal/types/memory.hpp
+++ b/include/cereal/types/memory.hpp
@@ -263,7 +263,7 @@ namespace cereal
   {
     auto & ptr = wrapper.ptr;
 
-    uint32_t id = ar.registerSharedPointer( ptr.get() );
+    uint32_t id = ar.registerSharedPointer( ptr );
     ar( CEREAL_NVP_("id", id) );
 
     if( id & detail::msb_32bit )


### PR DESCRIPTION
The archives use the memory address pointed by the shared_ptr as a
unique id which must not be reused during lifetime of the archive.
Therefore, the archives stores a copy of it.
This problem was also reported as CVE-2020-11105 and #636. This should fix #636.

My line of though was the following:
Correct usage of std::shared_ptr in Cereal requires that the shared_ptr is still valid at the point when all serialization occurs, usually at the end of the lifetime of the archive. It was suggested to document this constraint to the user, but since we are already dealing with smart pointers, I though, hey, let's implement this constraint by storing our own copy of the std::shared_ptr.