### PR TITLE
Use std::optional::emplace() when loading non-empty optional

### DIFF
--- a/include/cereal/types/optional.hpp
+++ b/include/cereal/types/optional.hpp
@@ -56,9 +56,8 @@ namespace cereal {
     if (nullopt) {
       optional = std::nullopt;
     } else {
-      T value;
-      ar(CEREAL_NVP_("data", value));
-      optional = std::move(value);
+      optional.emplace();
+      ar(CEREAL_NVP_("data", *optional));
     }
   }
 } // namespace cereal


### PR DESCRIPTION
This patch constructs and loads the contained value directly in place, instead of loading it outside and then moving it into place. This saves a move construction/assignment and thus benefits the case where moves aren't cheap (e.g. large POD).