### PR TITLE
Fix itsNextName not clearing when not found

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -572,7 +572,11 @@ namespace cereal
 
           // Do a search if we don't see a name coming up, or if the names don't match
           if( !actualName || std::strcmp( itsNextName, actualName ) != 0 )
-            itsIteratorStack.back().search( itsNextName );
+          {
+            auto temp = itsNextName;
+            itsNextName = nullptr;
+            itsIteratorStack.back().search( temp );
+          }
         }
 
         itsNextName = nullptr;


### PR DESCRIPTION
An issue exists when loading vectors of objects where, if the last nvp of
the previous object does not exist in the json file, the itsNextName
variable within the json serializer is not cleared. This causes the vector
serializer to search for that name next (when it should be searching for a
nameless object.) The json serializer then throws during the named search.

See sample code for demonstration. Before the change, the json serializer throws unexpectedly. After the change it behaves as I would expect.
[main.txt](https://github.com/USCiLab/cereal/files/6850772/main.txt)
