### PR TITLE
Use GNUInstallDirs instead of hard wiring install directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,14 +70,15 @@ endif()
 
 option(CEREAL_INSTALL "Generate the install target" ${CEREAL_MASTER_PROJECT})
 if(CEREAL_INSTALL)
+    include(GNUInstallDirs)
     include(CMakePackageConfigHelpers)
 
     install(TARGETS cereal EXPORT ${PROJECT_NAME}Targets)
-    install(DIRECTORY include/cereal DESTINATION include)
+    install(DIRECTORY include/cereal DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
     set(configFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake)
     set(versionFile ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake)
-    set(configInstallDestination lib/cmake/${PROJECT_NAME})
+    set(configInstallDestination ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
     configure_package_config_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in


### PR DESCRIPTION
On a multiarch setup cmake files should go into lib64.