### PR TITLE
Fixed compile error related to std::string in JSONOutputArchive

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -255,7 +255,8 @@ namespace cereal
       //! Saves a double to the current node
       void saveValue(double d)              { itsWriter.Double(d);                                                       }
       //! Saves a string to the current node
-      void saveValue(std::string const & s) { itsWriter.String(s.c_str(), static_cast<CEREAL_RAPIDJSON_NAMESPACE::SizeType>( s.size() )); }
+      template<class CharT, class Traits, class Alloc> inline
+      void saveValue(std::basic_string<CharT, Traits, Alloc>const& s) { itsWriter.String(s.c_str(), static_cast<CEREAL_RAPIDJSON_NAMESPACE::SizeType>(s.size())); }
       //! Saves a const char * to the current node
       void saveValue(char const * s)        { itsWriter.String(s);                                                       }
       //! Saves a nullptr to the current node


### PR DESCRIPTION
JSONOutputArchive expected an std::string param to be passed saveValue().
This caused the compilation to fail when the more generic std::basic_string was passed and not an std::string.
This fix changes the signature of saveValue to expect an std::basic_string