### PR TITLE
Fixed loading of std::vector<bool>

### DIFF
--- a/include/cereal/types/vector.hpp
+++ b/include/cereal/types/vector.hpp
@@ -100,7 +100,7 @@ namespace cereal
     ar( make_size_tag( size ) );
 
     vector.resize( static_cast<std::size_t>( size ) );
-    for(auto v : vector)
+    for(auto && v : vector)
     {
       bool b;
       ar( b );


### PR DESCRIPTION
We should use auto && instead of auto if we want to modify v inside the for loop.