### PR TITLE
Enhancement: Named Parameters (using C99 designated initializers) for the JSONArchiveWriter::Options class

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -118,6 +118,8 @@ namespace cereal
       //! A class containing various advanced options for the JSON archive
       class Options
       {
+
+
         public:
           //! Default options
           static Options Default(){ return Options(); }
@@ -134,18 +136,30 @@ namespace cereal
             carriage_return = '\r'
           };
 
+ 		  struct params
+		  {
+		  	std::size_t precision = JSONWriter::kDefaultMaxDecimalPlaces;
+		  	IndentChar indentChar = IndentChar::space;
+			std::size_t indentLength = 4;
+		  };
+
+
           //! Specify specific options for the JSONOutputArchive
           /*! @param precision The precision used for floating point numbers
               @param indentChar The type of character to indent with
               @param indentLength The number of indentChar to use for indentation
                              (0 corresponds to no indentation) */
-          explicit Options( int precision = JSONWriter::kDefaultMaxDecimalPlaces,
+           explicit Options( int precision = JSONWriter::kDefaultMaxDecimalPlaces,
                             IndentChar indentChar = IndentChar::space,
                             unsigned int indentLength = 4 ) :
             itsPrecision( precision ),
             itsIndentChar( static_cast<char>(indentChar) ),
             itsIndentLength( indentLength ) { }
 
+           Options(params p) :
+            itsPrecision( p.precision ),
+            itsIndentChar( static_cast<char>(p.indentChar) ),
+            itsIndentLength( p.indentLength ) { }
         private:
           friend class JSONOutputArchive;
           int itsPrecision;

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -118,8 +118,6 @@ namespace cereal
       //! A class containing various advanced options for the JSON archive
       class Options
       {
-
-
         public:
           //! Default options
           static Options Default(){ return Options(); }


### PR DESCRIPTION
Hello all, I've been looking into some serialization solutions for C++ and I love the simplicity of the Cereal API for the most part... but I feel that the JSONOutputArchive's configuration interface could use some love.

While I was writing some unit tests of my own classes' serialization functions, I noticed that the default handling of floating point numbers is to use very high precision, which made several float comparisons fail in some of tests once I'd serialized the values. 

 I looked into the JSONOutputArchive::Options class after searching the documentation and I found how to set the precision on the archiver, but I found this to be kind of awkward and not legible:

```
using JSONOptions =  cereal::JSONOutputArchive::Options;
cereal::JSONOutputArchive archive(buffer, JSONOptions(6));
```

My biggest concern with this is that it doesn't really tell you what option is being set to `6`... it's not the most legibble code. 

**This pull requests makes it possible to do something like this:**
```
using Options =  cereal::JSONOutputArchive::Options;
cereal::JSONOutputArchive archive(buffer,  JSONOptions{{.precision = 6}});
```
I suppose I could use a constant with a descriptive label for the value like `FLOAT_MAXPRECISION` in place of `6`, but I'd remembered reading about designated initializers in C99, and I've been using them in my own classes with C++11.

You can read more [here](https://pdimov.github.io/blog/2020/09/07/named-parameters-in-c20/):

> This works under GCC and Clang even without -std=c++20 because they support designated initializers in earlier language modes as an extension, and it works under MSVC with -std:c++latest.

I plan to use this modification in my own projects, since I'll be using primarily clang and gcc, maybe wrapped with `#ifdef MSVC` or something to that effect... but I thought to maybe contribute this back to the project...

Alternative Suggestion:
--- 
At the very least, if this change isn't merged (due to it requiring C++20, rather than C++11), then can we consider creating accessor methods or exposing the private variables in JSONOutputArchive::Options? Then something like this would be possible:

```
auto myOptions =  cereal::JSONOutputArchive::Default();
myOptions.precision = 6;
cereal::JSONOutputArchive archive(buffer, myOptions);
```