### PR TITLE
Disable portability test if -m32 is not supported(on arm and riscv)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ if(PROJECT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CEREAL_MASTER_PROJECT ON)
 endif()
 
+include(CheckCXXCompilerFlag)
+check_cxx_compiler_flag("-m32" COMPILER_HAVE_M32)
 
-if(APPLE)
+if(APPLE OR NOT COMPILER_HAVE_M32)
     option(SKIP_PORTABILITY_TEST "Skip portability (32 bit) tests" ON)
 endif()
 


### PR DESCRIPTION
On arm and riscv,  gcc doesn't have -m32/-m64 flag

This pr detects compiler support of -m32 and disable 32bits portability tests