### PR TITLE
Fix a performance bug when deserializing C arrays

### DIFF
--- a/include/cereal/types/common.hpp
+++ b/include/cereal/types/common.hpp
@@ -121,7 +121,8 @@ namespace cereal
   CEREAL_SERIALIZE_FUNCTION_NAME(Archive & ar, T & array)
   {
     common_detail::serializeArray( ar, array,
-        std::integral_constant<bool, traits::is_output_serializable<BinaryData<T>, Archive>::value &&
+        std::integral_constant<bool, (traits::is_output_serializable<BinaryData<T>, Archive>::value ||
+                                      traits::is_input_serializable<BinaryData<T>, Archive>::value) &&
                                      std::is_arithmetic<typename std::remove_all_extents<T>::type>::value>() );
   }
 } // namespace cereal


### PR DESCRIPTION
Without the proposed change, cereal will deserialize the C-array using the slow-path serializeArray(), i.e., the one that deserializes the array element by element, even though the array is arithmetic.