### PR TITLE
Add ARCH_INDEPENDENT flag in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,10 +87,11 @@ if(CEREAL_INSTALL)
         ${configFile}
         INSTALL_DESTINATION ${configInstallDestination}
     )
-    write_basic_package_version_file(
-        ${versionFile}
-        COMPATIBILITY SameMajorVersion
-    )
+    if(${CMAKE_VERSION} VERSION_GREATER 3.13)
+        write_basic_package_version_file("${versionFile}" COMPATIBILITY SameMajorVersion ARCH_INDEPENDENT)
+    else()
+        write_basic_package_version_file("${versionFile}" COMPATIBILITY SameMajorVersion)
+    endif()
 
     install(FILES ${configFile} ${versionFile} DESTINATION ${configInstallDestination})
     install(


### PR DESCRIPTION
If this package is flagged as ARCH_IDENPENDENT by cmake it is possible to consume the generated cmake files for compiling both 32bit and 64bit projects. Otherwise cmake will complain:
CMake Error at CMakeLists.txt:12 (find_package):
  Could not find a configuration file for package "cereal" that is compatible
  with requested version "".

  The following configuration files were considered but not accepted:

   cmake/cereal/cerealConfig.cmake, version: 1.3.2 (64bit)

For more info about this flag look here:
https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html