### PR TITLE
fix defer variable corruption

### DIFF
--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -338,8 +338,10 @@ namespace cereal
       /*! This will cause any data wrapped in DeferredData to be immediately serialized */
       void serializeDeferments()
       {
-        for( auto & deferment : itsDeferments )
-          deferment();
+        // for( auto & deferment : itsDeferments )
+        //   deferment();
+        for(int32_t i = 0; i < itsDeferments.size(); i++)
+          itsDeferments[i]();
       }
 
       /*! @name Boost Transition Layer
@@ -735,8 +737,10 @@ namespace cereal
       /*! This will cause any data wrapped in DeferredData to be immediately serialized */
       void serializeDeferments()
       {
-        for( auto & deferment : itsDeferments )
-          deferment();
+        // for( auto & deferment : itsDeferments )
+        //   deferment();
+        for(int32_t i = 0; i < itsDeferments.size(); i++)
+          itsDeferments[i]();
       }
 
       /*! @name Boost Transition Layer


### PR DESCRIPTION
As deferements are iterated using range based loop, when there is a recursive defer, it's corrupting the variable. The loop iteration has been changed to use index based to fix the same.

Kindly review it.  