### PR TITLE
sandbox: Do not use int8_t in std::uniform_int_distribution

### DIFF
--- a/sandbox/performance.cpp
+++ b/sandbox/performance.cpp
@@ -258,7 +258,7 @@ random_value(std::mt19937 & gen)
 {
   std::string s(std::uniform_int_distribution<int>(3, 30)(gen), ' ');
   for(char & c : s)
-    c = std::uniform_int_distribution<char>(' ', '~')(gen);
+    c = static_cast<char>( std::uniform_int_distribution<int>(' ', '~')(gen) );
   return s;
 }
 
@@ -277,7 +277,7 @@ std::string random_binary_string(std::mt19937 & gen)
 {
   std::string s(N, ' ');
   for(auto & c : s )
-    c = std::uniform_int_distribution<char>('0', '1')(gen);
+    c = static_cast<char>( std::uniform_int_distribution<int>( '0', '1' )(gen) );
   return s;
 }
 


### PR DESCRIPTION
Newer versions of libc++ has dropped supporting this usecase since its
an UB see.

https://reviews.llvm.org/D114920?id=400571

Fixes

uniform_int_distribution.h:162:5: error: static assertion failed due to requirement '__libcpp_random_is_valid_inttype<char>::value': IntType must be a supported integer type
    static_assert(__libcpp_random_is_valid_inttype<_IntType>::value, "IntType must be a supported integer type");
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux-musl/libcereal/1.3.2+gitAUTOINC+ebef1e9298-r0/git/sandbox/performance.cpp:261:9: note: in instantiation of template class 'std::uniform_int_distribution<char>' requested here
    c = std::uniform_int_distribution<char>(' ', '~')(gen);
        ^
/mnt/b/yoe/master/build/tmp/work/core2-64-yoe-linux-musl/libcereal/1.3.2+gitAUTOINC+ebef1e9298-r0/git/sandbox/performance.cpp:261:9: error: type 'std::uniform_int_distribution<char>' does not provide a call operator
    c = std::uniform_int_distribution<char>(' ', '~')(gen);
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.

Signed-off-by: Khem Raj <raj.khem@gmail.com>