### PR TITLE
Marking constructors as noexcept when possible

### DIFF
--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -54,7 +54,7 @@ namespace cereal
       //! Construct, outputting to the provided stream
       /*! @param stream The stream to output to.  Can be a stringstream, a file stream, or
                         even cout! */
-      BinaryOutputArchive(std::ostream & stream) :
+      BinaryOutputArchive(std::ostream & stream) CEREAL_NOEXCEPT :
         OutputArchive<BinaryOutputArchive, AllowEmptyClassElision>(this),
         itsStream(stream)
       { }
@@ -89,7 +89,7 @@ namespace cereal
   {
     public:
       //! Construct, loading from the provided stream
-      BinaryInputArchive(std::istream & stream) :
+      BinaryInputArchive(std::istream & stream) CEREAL_NOEXCEPT :
         InputArchive<BinaryInputArchive, AllowEmptyClassElision>(this),
         itsStream(stream)
       { }

--- a/include/cereal/cereal.hpp
+++ b/include/cereal/cereal.hpp
@@ -320,7 +320,7 @@ namespace cereal
     public:
       //! Construct the output archive
       /*! @param derived A pointer to the derived ArchiveType (pass this from the derived archive) */
-      OutputArchive(ArchiveType * const derived) : self(derived), itsCurrentPointerId(1), itsCurrentPolymorphicTypeId(1)
+      OutputArchive(ArchiveType * const derived) CEREAL_NOEXCEPT : self(derived), itsCurrentPointerId(1), itsCurrentPolymorphicTypeId(1)
       { }
 
       OutputArchive & operator=( OutputArchive const & ) = delete;
@@ -712,7 +712,7 @@ namespace cereal
     public:
       //! Construct the output archive
       /*! @param derived A pointer to the derived ArchiveType (pass this from the derived archive) */
-      InputArchive(ArchiveType * const derived) :
+      InputArchive(ArchiveType * const derived) CEREAL_NOEXCEPT :
         self(derived),
         itsBaseClassSet(),
         itsSharedPointerMap(),


### PR DESCRIPTION
See [C++ Core Guidelines C.44](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#c44-prefer-default-constructors-to-be-simple-and-non-throwing)
As opposed to the Binary archive, for the PortableBinary, JSON and XML archives, the constructor can throw if the stream is not opened or is not in goodbit, which is a problem...