### PR TITLE
handle trivially-copyable types correctly

### DIFF
--- a/include/cereal/types/array.hpp
+++ b/include/cereal/types/array.hpp
@@ -39,7 +39,7 @@ namespace cereal
   //! using binary serialization, if supported
   template <class Archive, class T, size_t N> inline
   typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
+                          && std::is_trivially_copyable<T>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::array<T, N> const & array )
   {
     ar( binary_data( array.data(), sizeof(array) ) );
@@ -49,7 +49,7 @@ namespace cereal
   //! using binary serialization, if supported
   template <class Archive, class T, size_t N> inline
   typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
+                          && std::is_trivially_copyable<T>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::array<T, N> & array )
   {
     ar( binary_data( array.data(), sizeof(array) ) );
@@ -58,7 +58,7 @@ namespace cereal
   //! Saving for std::array all other types
   template <class Archive, class T, size_t N> inline
   typename std::enable_if<!traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::array<T, N> const & array )
   {
     for( auto const & i : array )
@@ -68,7 +68,7 @@ namespace cereal
   //! Loading for std::array all other types
   template <class Archive, class T, size_t N> inline
   typename std::enable_if<!traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::array<T, N> & array )
   {
     for( auto & i : array )

--- a/include/cereal/types/common.hpp
+++ b/include/cereal/types/common.hpp
@@ -36,7 +36,7 @@ namespace cereal
 {
   namespace common_detail
   {
-    //! Serialization for arrays if BinaryData is supported and we are arithmetic
+    //! Serialization for arrays if BinaryData is supported and we are trivially-copyable
     /*! @internal */
     template <class Archive, class T> inline
     void serializeArray( Archive & ar, T & array, std::true_type /* binary_supported */ )
@@ -44,7 +44,7 @@ namespace cereal
       ar( binary_data( array, sizeof(array) ) );
     }
 
-    //! Serialization for arrays if BinaryData is not supported or we are not arithmetic
+    //! Serialization for arrays if BinaryData is not supported or we are not trivially-copyable
     /*! @internal */
     template <class Archive, class T> inline
     void serializeArray( Archive & ar, T & array, std::false_type /* binary_supported */ )
@@ -122,7 +122,7 @@ namespace cereal
   {
     common_detail::serializeArray( ar, array,
         std::integral_constant<bool, traits::is_output_serializable<BinaryData<T>, Archive>::value &&
-                                     std::is_arithmetic<typename std::remove_all_extents<T>::type>::value>() );
+                                     std::is_trivially_copyable<typename std::remove_all_extents<T>::type>::value>() );
   }
 } // namespace cereal
 

--- a/include/cereal/types/valarray.hpp
+++ b/include/cereal/types/valarray.hpp
@@ -37,20 +37,20 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace cereal
 {
-  //! Saving for std::valarray arithmetic types, using binary serialization, if supported
+  //! Saving for std::valarray trivially-copyable types, using binary serialization, if supported
   template <class Archive, class T> inline
   typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
+                          && std::is_trivially_copyable<T>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::valarray<T> const & valarray )
   {
     ar( make_size_tag( static_cast<size_type>(valarray.size()) ) ); // number of elements
     ar( binary_data( &valarray[0], valarray.size() * sizeof(T) ) ); // &valarray[0] ok since guaranteed contiguous
   }
 
-  //! Loading for std::valarray arithmetic types, using binary serialization, if supported
+  //! Loading for std::valarray trivially-copyable types, using binary serialization, if supported
   template <class Archive, class T> inline
   typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
+                          && std::is_trivially_copyable<T>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::valarray<T> & valarray )
   {
     size_type valarraySize;
@@ -63,7 +63,7 @@ namespace cereal
   //! Saving for std::valarray all other types
   template <class Archive, class T> inline
   typename std::enable_if<!traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::valarray<T> const & valarray )
   {
     ar( make_size_tag( static_cast<size_type>(valarray.size()) ) ); // number of elements
@@ -74,7 +74,7 @@ namespace cereal
   //! Loading for std::valarray all other types
   template <class Archive, class T> inline
   typename std::enable_if<!traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::valarray<T> & valarray )
   {
     size_type valarraySize;

--- a/include/cereal/types/vector.hpp
+++ b/include/cereal/types/vector.hpp
@@ -35,20 +35,20 @@
 
 namespace cereal
 {
-  //! Serialization for std::vectors of arithmetic (but not bool) using binary serialization, if supported
+  //! Serialization for std::vectors of trivially-copyable (but not bool) using binary serialization, if supported
   template <class Archive, class T, class A> inline
   typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value && !std::is_same<T, bool>::value, void>::type
+                          && std::is_trivially_copyable<T>::value && !std::is_same<T, bool>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::vector<T, A> const & vector )
   {
     ar( make_size_tag( static_cast<size_type>(vector.size()) ) ); // number of elements
     ar( binary_data( vector.data(), vector.size() * sizeof(T) ) );
   }
 
-  //! Serialization for std::vectors of arithmetic (but not bool) using binary serialization, if supported
+  //! Serialization for std::vectors of trivially-copyable (but not bool) using binary serialization, if supported
   template <class Archive, class T, class A> inline
   typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value && !std::is_same<T, bool>::value, void>::type
+                          && std::is_trivially_copyable<T>::value && !std::is_same<T, bool>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::vector<T, A> & vector )
   {
     size_type vectorSize;
@@ -58,10 +58,10 @@ namespace cereal
     ar( binary_data( vector.data(), static_cast<std::size_t>( vectorSize ) * sizeof(T) ) );
   }
 
-  //! Serialization for non-arithmetic vector types
+  //! Serialization for non-trivially-copyable vector types
   template <class Archive, class T, class A> inline
   typename std::enable_if<(!traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value) && !std::is_same<T, bool>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value) && !std::is_same<T, bool>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::vector<T, A> const & vector )
   {
     ar( make_size_tag( static_cast<size_type>(vector.size()) ) ); // number of elements
@@ -69,10 +69,10 @@ namespace cereal
       ar( v );
   }
 
-  //! Serialization for non-arithmetic vector types
+  //! Serialization for non-trivially-copyable vector types
   template <class Archive, class T, class A> inline
   typename std::enable_if<(!traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          || !std::is_arithmetic<T>::value) && !std::is_same<T, bool>::value, void>::type
+                          || !std::is_trivially_copyable<T>::value) && !std::is_same<T, bool>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::vector<T, A> & vector )
   {
     size_type size;


### PR DESCRIPTION
Cereal has two implementations for contiguous standard library containers:
  1. serialise element-wise (default)
  2. serialise en-bloc

The second implementation is only chosen for arithmetic element types when, in fact, it should be chosen for all trivially-copyable types; this is exactly what the trivially-copyable trait was made for 🙂 

This PR changes the behaviour. It reduces the deserialisation time in one of our applications by more than 5x!

Note that the on-disk representation is not guaranteed to stay the same, although in many cases it will.