### PR TITLE
Kpe 51 klepsydra sdk on free rtos

### DIFF
--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -426,7 +426,12 @@ namespace cereal
   {
     private:
       using ReadStream = CEREAL_RAPIDJSON_NAMESPACE::IStreamWrapper;
+#ifndef __freertos__
       typedef CEREAL_RAPIDJSON_NAMESPACE::GenericValue<CEREAL_RAPIDJSON_NAMESPACE::UTF8<>> JSONValue;
+#else
+      typedef CEREAL_RAPIDJSON_NAMESPACE::GenericValue<CEREAL_RAPIDJSON_NAMESPACE::UTF8<>,
+                                                       CEREAL_RAPIDJSON_NAMESPACE::MemoryPoolAllocator<CEREAL_RAPIDJSON_NAMESPACE::FrtosAllocator>> JSONValue;
+#endif
       typedef JSONValue::ConstMemberIterator MemberIterator;
       typedef JSONValue::ConstValueIterator ValueIterator;
       typedef CEREAL_RAPIDJSON_NAMESPACE::Document::GenericValue GenericValue;

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -248,10 +248,12 @@ namespace cereal
       void saveValue(int i)                 { itsWriter.Int(i);                                                          }
       //! Saves a uint to the current node
       void saveValue(unsigned u)            { itsWriter.Uint(u);                                                         }
+#if LONG_MAX == 0x7FFFFFFFL
       //! Saves a long to the current node
       void saveValue(long i)                { itsWriter.Int(i);                                                          }
       //! Saves a ulong to the current node
       void saveValue(unsigned long u)       { itsWriter.Uint(u);                                                         }
+#endif // LONG_MAX == 0x7FFFFFFFL
       //! Saves an int64 to the current node
       void saveValue(int64_t i64)           { itsWriter.Int64(i64);                                                      }
       //! Saves a uint64 to the current node

--- a/include/cereal/archives/json.hpp
+++ b/include/cereal/archives/json.hpp
@@ -248,6 +248,10 @@ namespace cereal
       void saveValue(int i)                 { itsWriter.Int(i);                                                          }
       //! Saves a uint to the current node
       void saveValue(unsigned u)            { itsWriter.Uint(u);                                                         }
+      //! Saves a long to the current node
+      void saveValue(long i)                { itsWriter.Int(i);                                                          }
+      //! Saves a ulong to the current node
+      void saveValue(unsigned long u)       { itsWriter.Uint(u);                                                         }
       //! Saves an int64 to the current node
       void saveValue(int64_t i64)           { itsWriter.Int64(i64);                                                      }
       //! Saves a uint64 to the current node

--- a/include/cereal/external/rapidjson/document.h
+++ b/include/cereal/external/rapidjson/document.h
@@ -2107,7 +2107,11 @@ private:
 };
 
 //! GenericValue with UTF8 encoding
+#ifndef __freertos__
 typedef GenericValue<UTF8<> > Value;
+#else
+typedef GenericValue<UTF8<>, MemoryPoolAllocator<FrtosAllocator>> Value;
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 // GenericDocument
@@ -2503,7 +2507,11 @@ private:
 };
 
 //! GenericDocument with UTF8 encoding
+#ifndef __freertos__
 typedef GenericDocument<UTF8<> > Document;
+#else
+typedef GenericDocument<UTF8<>, MemoryPoolAllocator<FrtosAllocator>, FrtosAllocator> Document;
+#endif
 
 //! Helper class for accessing Value of array type.
 /*!


### PR DESCRIPTION
typedef Document, Value and JSONValue providing Allocator class, overriding default argument for type name, to avoid problems with long names in JSON name-value pairs

[https://github.com/Tencent/rapidjson/issues/1959](https://github.com/Tencent/rapidjson/issues/1959)