### PR TITLE
cmake: Use -idirafter instead of -isystem

### DIFF
--- a/unittests/boost/CMakeLists.txt
+++ b/unittests/boost/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.cpp)
 
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -idirafter ${Boost_INCLUDE_DIRS}")
 
 # Build all of the non-special tests
 foreach(TEST_SOURCE ${TESTS})


### PR DESCRIPTION
isystem dirs are searched before the regular system dirs this exposes an interesting include ordering problem when using clang + libc++, when including C++ headers like <cstdlib>

cstdlib includes stdlib.h and in case of libc++, this should be coming from libc++ as well, which is then eventually including system stdlib.h

libc++ has added a check for checking this order recently, which means if cstlib ends up including system stdlib.h before libc++ provided stdlib.h it errors out

| /mnt/b/yoe/master/build/tmp/work/riscv64-yoe-linux/libcereal/1.3.2+gitAUTOINC+ebef1e9298-r0/recipe-sysroot/usr/include/c++/v1/cwchar:113:5: error: <cwchar> tried including <wchar.h> but didn't find libc++'s <wcha
r.h> header.           This usually means that your header search paths are not configured properly.           The header search paths should contain the C++ Standard Library headers before           any C Standard
 Library, and you are probably using compiler flags that make that           not be the case.                                                                                                                         | #   error <cwchar> tried including <wchar.h> but didn't find libc++'s <wchar.h> header. \
|     ^

The reason is that include_directories with SYSTEM property adds the directory via -system and some of these directories point to sysroot e.g. OPENSSL_INCLUDE_DIR which ends up adding -isystem <sysroot>/usr/include and causes the system stdlib.h to included before libc++ stdlib.h

A fix is to use -idirafter which preserved the effects of system headers but instead of prepending, it will append to system headers and the issue is addressed

Signed-off-by: Khem Raj <raj.khem@gmail.com>