### PR TITLE
Make the -DTHREAD_SAFE cmake option change the target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,8 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.0) # installing cereal requires INTERFACE li
 endif()
 
 
-set(CEREAL_THREAD_LIBS)
 if(UNIX)
     option(THREAD_SAFE "Use mutexes to ensure thread safety" OFF)
-    if(THREAD_SAFE)
-        message(STATUS "Use mutexes")
-        add_definitions(-DCEREAL_THREAD_SAFE=1)
-        set(CEREAL_THREAD_LIBS pthread)
-    endif()
 endif()
 
 
@@ -63,7 +57,11 @@ target_include_directories(cereal INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-list(APPEND CEREAL_THREAD_LIBS cereal::cereal)
+if(THREAD_SAFE)
+    message(STATUS "Use mutexes")
+    target_compile_definitions(cereal INTERFACE CEREAL_THREAD_SAFE=1)
+    target_link_libraries(cereal INTERFACE pthread)
+endif()
 
 if(NOT CMAKE_VERSION VERSION_LESS 3.8)
     target_compile_features(cereal INTERFACE cxx_std_11)


### PR DESCRIPTION
Issue: Configuring cereal with the -DTHREAD_SAFE=ON option will not lead to any change in the installation.

I would like to have a system install defaulting to thread safe code, but I am not sure how the best way to solve this issue looks like. One option would be to change the default value of CEREAL_THREAD_SAFE in macros.hpp; the other option would be to create cmake targets which set the relevant compiler flags. The first solution would still suffer from not having proper support for linking a threading library.

The implemented solution tries to adjust CMakeLists.txt in such a way that it does what I think it should have done all along:

Using target_compile_definitions and target_link_libraries, the cmake targets installed in PREFIX/cmake/cereal will be updated to include the definition and library for thread safety. This will result in projects using cmake to include cereal automatically using the thread safe code globally.

A third option could be to provide two different cmake targets, one for single threaded and for multi threaded targets.

Resolves #785