### PR TITLE
Add missing noexcept

### DIFF
--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -1158,7 +1158,7 @@ namespace cereal
           void const * ptr;
           size_t hash;
       };
-      struct base_class_id_hash { size_t operator()(base_class_id const & id) const { return id.hash; }  };
+      struct base_class_id_hash { size_t operator()(base_class_id const & id) const noexcept { return id.hash; }  };
     } // namespace detail
 
     namespace detail


### PR DESCRIPTION
This causes various warning for me when using `-Wnoexcept`. As I see it, the current implementation cannot throw. Has there been deliberate choice to not mark this `noexcept` as a future implementation might throw?