### PR TITLE
Fix instances of -Wmissing-template-arg-list-after-template-kw.

### DIFF
--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -95,7 +95,7 @@ namespace cereal
       template <class Archive, class ... Types> inline
       static void apply( Archive & ar, std::tuple<Types...> & tuple )
       {
-        serialize<Height - 1>::template apply( ar, tuple );
+        serialize<Height - 1>::apply( ar, tuple );
         ar( CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
             std::get<Height - 1>( tuple )) );
       }
@@ -116,7 +116,7 @@ namespace cereal
   template <class Archive, class ... Types> inline
   void CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, std::tuple<Types...> & tuple )
   {
-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply( ar, tuple );
+    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::apply( ar, tuple );
   }
 } // namespace cereal
 


### PR DESCRIPTION
Clang has a new warning that requires a template argument list after using the template keyword. Remove uses of the template keyword when we're not specifying types.

See https://github.com/llvm/llvm-project/issues/94194 for the upstream clang changes