### PR TITLE
create pkgconfig file during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,21 @@ if(CEREAL_INSTALL)
     else()
         write_basic_package_version_file("${versionFile}" COMPATIBILITY SameMajorVersion)
     endif()
+    configure_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
+        @ONLY
+    )
 
     install(FILES ${configFile} ${versionFile} DESTINATION ${configInstallDestination})
     install(
         EXPORT ${PROJECT_NAME}Targets
         NAMESPACE "cereal::"
         DESTINATION ${configInstallDestination}
+    )
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig
     )
 endif()
 

--- a/cereal.pc.in
+++ b/cereal.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: cereal is a header-only C++11 serialization library
+URL: https://uscilab.github.io/cereal/
+Version: @PROJECT_VERSION@
+Cflags: -I"${includedir}"


### PR DESCRIPTION
Add a template `cereal.pc.in` and modified `CMakeLists` to create `cereal.pc` and install it into `share/pkgconfig/`.

I hardcoded `Description:` and `URL:` within `cereal.pc.in` so as not to push forward the required CMake version, `DESCRIPTION` for projects appears in 3.9 and `HOMEPAGE_URL` in 3.12.