### PR TITLE
Fix `std::array<T,0>`

### DIFF
--- a/include/cereal/types/array.hpp
+++ b/include/cereal/types/array.hpp
@@ -42,13 +42,8 @@ namespace cereal
                           && std::is_arithmetic<T>::value, void>::type
   CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::array<T, N> const & array )
   {
-    ar( binary_data( array.data(), sizeof(array) ) );
+    ar( binary_data( array.data(), N*sizeof(T) ) );
   }
-
-  template <class Archive, class T> inline
-  typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
-  CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::array<T, 0> const & array ) {}
 
   //! Loading for std::array primitive types
   //! using binary serialization, if supported
@@ -57,13 +52,8 @@ namespace cereal
                           && std::is_arithmetic<T>::value, void>::type
   CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::array<T, N> & array )
   {
-    ar( binary_data( array.data(), sizeof(array) ) );
+    ar( binary_data( array.data(), N*sizeof(T) ) );
   }
-
-  template <class Archive, class T> inline
-  typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
-                          && std::is_arithmetic<T>::value, void>::type
-  CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::array<T, 0> & array ) {}
 
   //! Saving for std::array all other types
   template <class Archive, class T, size_t N> inline

--- a/include/cereal/types/array.hpp
+++ b/include/cereal/types/array.hpp
@@ -45,6 +45,11 @@ namespace cereal
     ar( binary_data( array.data(), sizeof(array) ) );
   }
 
+  template <class Archive, class T> inline
+  typename std::enable_if<traits::is_output_serializable<BinaryData<T>, Archive>::value
+                          && std::is_arithmetic<T>::value, void>::type
+  CEREAL_SAVE_FUNCTION_NAME( Archive & ar, std::array<T, 0> const & array ) {}
+
   //! Loading for std::array primitive types
   //! using binary serialization, if supported
   template <class Archive, class T, size_t N> inline
@@ -54,6 +59,11 @@ namespace cereal
   {
     ar( binary_data( array.data(), sizeof(array) ) );
   }
+
+  template <class Archive, class T> inline
+  typename std::enable_if<traits::is_input_serializable<BinaryData<T>, Archive>::value
+                          && std::is_arithmetic<T>::value, void>::type
+  CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::array<T, 0> & array ) {}
 
   //! Saving for std::array all other types
   template <class Archive, class T, size_t N> inline

--- a/unittests/array.cpp
+++ b/unittests/array.cpp
@@ -31,22 +31,26 @@ TEST_SUITE_BEGIN("array");
 
 TEST_CASE("binary_array")
 {
-  test_array<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+  test_array<cereal::BinaryInputArchive, cereal::BinaryOutputArchive, 0>();
+  test_array<cereal::BinaryInputArchive, cereal::BinaryOutputArchive, 100>();
 }
 
 TEST_CASE("portable_binary_array")
 {
-  test_array<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+  test_array<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive, 0>();
+  test_array<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive, 100>();
 }
 
 TEST_CASE("xml_array")
 {
-  test_array<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+  test_array<cereal::XMLInputArchive, cereal::XMLOutputArchive, 0>();
+  test_array<cereal::XMLInputArchive, cereal::XMLOutputArchive, 100>();
 }
 
 TEST_CASE("json_array")
 {
-  test_array<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+  test_array<cereal::JSONInputArchive, cereal::JSONOutputArchive, 0>();
+  test_array<cereal::JSONInputArchive, cereal::JSONOutputArchive, 100>();
 }
 
 TEST_SUITE_END();

--- a/unittests/array.hpp
+++ b/unittests/array.hpp
@@ -28,7 +28,7 @@
 #define CEREAL_TEST_ARRAY_H_
 #include "common.hpp"
 
-template <class IArchive, class OArchive> inline
+template <class IArchive, class OArchive, size_t N> inline
 void test_array()
 {
   std::random_device rd;
@@ -36,23 +36,23 @@ void test_array()
 
   for(int ii=0; ii<100; ++ii)
   {
-    std::array<int, 100> o_podarray;
+    std::array<int, N> o_podarray;
     for(auto & elem : o_podarray)
       elem = random_value<int>(gen);
 
-    std::array<StructInternalSerialize, 100> o_iserarray;
+    std::array<StructInternalSerialize, N> o_iserarray;
     for(auto & elem : o_iserarray)
       elem = StructInternalSerialize( random_value<int>(gen), random_value<int>(gen) );
 
-    std::array<StructInternalSplit, 100> o_isplarray;
+    std::array<StructInternalSplit, N> o_isplarray;
     for(auto & elem : o_isplarray)
       elem = StructInternalSplit( random_value<int>(gen), random_value<int>(gen) );
 
-    std::array<StructExternalSerialize, 100> o_eserarray;
+    std::array<StructExternalSerialize, N> o_eserarray;
     for(auto & elem : o_eserarray)
       elem = StructExternalSerialize( random_value<int>(gen), random_value<int>(gen) );
 
-    std::array<StructExternalSplit, 100> o_esplarray;
+    std::array<StructExternalSplit, N> o_esplarray;
     for(auto & elem : o_esplarray)
       elem = StructExternalSplit( random_value<int>(gen), random_value<int>(gen) );
 
@@ -67,11 +67,11 @@ void test_array()
       oar(o_esplarray);
     }
 
-    std::array<int, 100> i_podarray;
-    std::array<StructInternalSerialize, 100> i_iserarray;
-    std::array<StructInternalSplit, 100>     i_isplarray;
-    std::array<StructExternalSerialize, 100> i_eserarray;
-    std::array<StructExternalSplit, 100>     i_esplarray;
+    std::array<int, N> i_podarray;
+    std::array<StructInternalSerialize, N> i_iserarray;
+    std::array<StructInternalSplit, N>     i_isplarray;
+    std::array<StructExternalSerialize, N> i_eserarray;
+    std::array<StructExternalSplit, N>     i_esplarray;
 
     std::istringstream is(os.str());
     {


### PR DESCRIPTION
For `std::array<T,0>`, the `sizeof(array)!=0`.
Then bugs appear at
https://github.com/USCiLab/cereal/blob/master/include/cereal/types/array.hpp#L45
and
https://github.com/USCiLab/cereal/blob/master/include/cereal/types/array.hpp#L55 ,
since `array.data()` is `nullptr` for `std::array<T,0>`.