### PR TITLE
Fix llvm20 compile issue in tuple.hpp

### DIFF
--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -95,7 +95,7 @@ namespace cereal
       template <class Archive, class ... Types> inline
       static void apply( Archive & ar, std::tuple<Types...> & tuple )
       {
-        serialize<Height - 1>::template apply( ar, tuple );
+        serialize<Height - 1>::template apply<Archive, Types...>( ar, tuple );
         ar( CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
             std::get<Height - 1>( tuple )) );
       }
@@ -116,7 +116,7 @@ namespace cereal
   template <class Archive, class ... Types> inline
   void CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, std::tuple<Types...> & tuple )
   {
-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply( ar, tuple );
+    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply<Archive, Types...>( ar, tuple );
   }
 } // namespace cereal
 


### PR DESCRIPTION
I encountered a compilation issue with my library using cereal when I tried to compile it with clang++-20.  GCC is still working fine, but it is not accepted by clang++-20. This PR introduces a minor change that fixes the issue. AFAIK, GCC is accepting this because of the bug. 
https://github.com/llvm/llvm-project/issues/94194