### PR TITLE
Clang 20 build fixup

### DIFF
--- a/include/cereal/external/rapidjson/document.h
+++ b/include/cereal/external/rapidjson/document.h
@@ -321,8 +321,8 @@ struct GenericStringRef {
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 
-    const Ch* const s; //!< plain CharType pointer
-    const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
+    const Ch* s; //!< plain CharType pointer
+    SizeType length; //!< length of the string (excluding the trailing NULL terminator)
 
 private:
     //! Disallow construction from non-const array


### PR DESCRIPTION
# Changes

This PR is to fix the code up so that the Clang 20 compiler can build the cereal library without issue. Before this fix, I would get the following error:

```
/home/rodrigor/Workspace/swift-nav/orion/third_party/orion-engine/third_party/albatross/third_party/cereal/include/cereal/external/rapidjson/document.h:319:82: error: cannot assign to non-static data member 'length' with const-qualified type 'const SizeType' (aka 'const unsigned int')
  319 |     GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
      |                                                                           ~~~~~~ ^
/home/rodrigor/Workspace/swift-nav/orion/third_party/orion-engine/third_party/albatross/third_party/cereal/include/cereal/external/rapidjson/document.h:325:20: note: non-static data member 'length' declared const here
  325 |     const SizeType length; //!< length of the string (excluding the trailing NULL terminator)
```

The reason is that the `operator=(const GenericStringRef&)` function is not `const` and is modifying the member variables which unfortunately are `const`, so its a build failure. Removing he `const` constraint fixes things. Not sure how this wasn't identified earlier as a problem by GCC or clang.