### PR TITLE
Fix multicontainer deserialization

### DIFF
--- a/include/cereal/types/map.hpp
+++ b/include/cereal/types/map.hpp
@@ -33,4 +33,55 @@
 #include "cereal/types/concepts/pair_associative_container.hpp"
 #include <map>
 
+namespace cereal
+{
+  /**
+    * std::multimap must not default to the implementation in
+    * pair_associative_container.hpp, because it incorrectly
+    * handles equivalent keys when loading the map.
+    *
+    * The cause is the use of emplace_hint.
+    * Since it iserts the value before the hint, key order will be flipped
+    *
+    * Here we are using emplace (if key is equivalent to the previous one),
+    * or emplace_hint if keys are different, because this is a faster path
+    *
+    * Emplace will preserve order of equivalent keys, while where
+    * non-equivalent ones are placed doesn't matter.
+    **/
+
+  template <class Archive, typename... Args>
+  inline void load(Archive &ar, std::multimap<Args...> &map)
+  {
+    size_type size;
+    ar(make_size_tag(size));
+
+    map.clear();
+
+    typename std::multimap<Args...>::key_compare cmp;
+    auto hint = map.begin();
+    for (size_t i = 0; i < size; ++i)
+    {
+      typename std::multimap<Args...>::key_type key;
+      typename std::multimap<Args...>::mapped_type value;
+
+      ar(make_map_item(key, value));
+      if(!cmp(hint->first, key) && !cmp(key, hint->first)) {
+        #ifdef CEREAL_OLDER_GCC
+        hint = map.insert(std::move(key), std::move(value));
+        #else // NOT CEREAL_OLDER_GCC
+        hint = map.emplace(std::move(key), std::move(value));
+        #endif // NOT CEREAL_OLDER_GCC
+      } else {
+        #ifdef CEREAL_OLDER_GCC
+        hint = map.insert_hint(hint, std::move(key), std::move(value));
+        #else // NOT CEREAL_OLDER_GCC
+        hint = map.emplace_hint(hint, std::move(key), std::move(value));
+        #endif // NOT CEREAL_OLDER_GCC
+      }
+
+    }
+  }
+}
+
 #endif // CEREAL_TYPES_MAP_HPP_

--- a/include/cereal/types/set.hpp
+++ b/include/cereal/types/set.hpp
@@ -96,7 +96,34 @@ namespace cereal
   template <class Archive, class K, class C, class A> inline
   void CEREAL_LOAD_FUNCTION_NAME( Archive & ar, std::multiset<K, C, A> & multiset )
   {
-    set_detail::load( ar, multiset );
+    size_type size;
+    ar( make_size_tag( size ) );
+
+    multiset.clear();
+
+    typename std::multiset<K, C, A>::key_compare cmp;
+
+    auto hint = multiset.begin();
+    for( size_type i = 0; i < size; ++i )
+    {
+      typename std::multiset<K, C, A>::key_type key;
+      ar( key );
+
+      // if hint == key
+      if(!cmp(*hint, key) && !cmp(key, *hint)) {
+        #ifdef CEREAL_OLDER_GCC
+        hint = multiset.insert(std::move(key));
+        #else // NOT CEREAL_OLDER_GCC
+        hint = multiset.emplace(std::move(key));
+        #endif // NOT CEREAL_OLDER_GCC
+      }else {
+        #ifdef CEREAL_OLDER_GCC
+        hint = multiset.insert_hint( hint, std::move( key ) );
+        #else // NOT CEREAL_OLDER_GCC
+        hint = multiset.emplace_hint( hint, std::move( key ) );
+        #endif // NOT CEREAL_OLDER_GCC
+      }
+    }
   }
 } // namespace cereal
 


### PR DESCRIPTION
# Subject

As reported in this issue ( https://github.com/USCiLab/cereal/issues/865 ), deserialization of the std::multimap and std::multiset breaks the container invariants. These containers are expected ( by the standard ), to maintain the relative (insertion) order of the values who's keys evaluate as equivalent. 

The `load` method for these containers uses `insert_hint(hint, value)` ( or `emplace_hint` ) methods to add values to the container during load. This results in reversing the order of the elements with equivalent keys, because the method places the new element before the `hint` instead of after. 

# Solution

Implement handlers for these method separately instead of generically. Regular emplace is needed in order to maintain the insertion order of equivalent keys. For keys that are not equivalent there is no expectation of order so they can be placed in any order. In order to still maintain the benefits of the faster `emplace_hint`, it is still used when the current key is not equivalent to the previous. If the current key is equivalent to the previous key, `emplace` needs to be used.

# Testing

By running the following cmake commands old I asserted that the current behaviour was not broken:
```bash
> cmake -DCMAKE_BUILD_TYPE=Debug -DSKIP_PERFORMANCE_COMPARISON=YES -B build -DSKIP_PORTABILITY_TEST=TRUE -DCMAKE_CXX_STANDARD=17
> cmake --build build
> cmake --build build --target test
```

The new behaviour was tested using the script given in the original issue.

# Compilation issues
The cmake build seems to be broken in some files. In order to build the test at all the following diffs were applied:

```diff
diff --git a/include/cereal/details/helpers.hpp b/include/cereal/details/helpers.hpp
index 8dafb8e..0f058ac 100644
--- a/include/cereal/details/helpers.hpp
+++ b/include/cereal/details/helpers.hpp
@@ -244,8 +244,6 @@ namespace cereal
       static_assert( !std::is_base_of<detail::DeferredDataCore, T>::value,
                      "Cannot defer DeferredData" );
 
-      DeferredData & operator=( DeferredData const & ) = delete;
-
     public:
       //! Constructs a new NameValuePair
       /*! @param v The value to defer.  Ideally this should be an l-value reference so that
```

```diff
diff --git a/include/cereal/types/tuple.hpp b/include/cereal/types/tuple.hpp
index 80c6807..d690199 100644
--- a/include/cereal/types/tuple.hpp
+++ b/include/cereal/types/tuple.hpp
@@ -95,7 +95,7 @@ namespace cereal
       template <class Archive, class ... Types> inline
       static void apply( Archive & ar, std::tuple<Types...> & tuple )
       {
-        serialize<Height - 1>::template apply( ar, tuple );
+        serialize<Height - 1>::apply( ar, tuple );
         ar( CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
             std::get<Height - 1>( tuple )) );
       }
@@ -116,7 +116,7 @@ namespace cereal
   template <class Archive, class ... Types> inline
   void CEREAL_SERIALIZE_FUNCTION_NAME( Archive & ar, std::tuple<Types...> & tuple )
   {
-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply( ar, tuple );
+    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>:: apply( ar, tuple );
   }
 } // namespace cereal
 ```
 
 ```diff
 diff --git a/unittests/doctest.h b/unittests/doctest.h
index cd5b44d..307315f 100644
--- a/unittests/doctest.h
+++ b/unittests/doctest.h
@@ -3631,7 +3631,7 @@ String toString(double long in) { return fpToString(in, 15); }
 #define DOCTEST_TO_STRING_OVERLOAD(type, fmt)                                                      \
     String toString(type in) {                                                                     \
         char buf[64];                                                                              \
-        std::sprintf(buf, fmt, in);                                                                \
+        std::snprintf(buf, 64, fmt, in);                                                           \
         return buf;                                                                                \
     }
 ```
 