### PR TITLE
Fix the MacOS  workflow

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   test_cereal_macos:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -11,12 +11,14 @@ jobs:
           - CMAKE_OPTIONS: '-DWITH_WERROR=OFF -DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
             COMPILER: 'clang++'
             XCODE_VERSION: 15
-            NAME: macos-latest-clang-xcode15
+            NAME: macos-14-clang-xcode15
+            os: macos-14
 
           - CMAKE_OPTIONS: '-DWITH_WERROR=OFF -DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
             COMPILER: 'clang++'
             XCODE_VERSION: 16
-            NAME: macos-latest-clang-xcode16
+            NAME: macos-15-clang-xcode16
+            os: macos-15
     name: ${{ matrix.name }}
 
     steps:


### PR DESCRIPTION
Fixes the failure of the macOS GitHub workflow.

As described [here](https://github.com/USCiLab/cereal/pull/878#issuecomment-4017737790) the issue is related to the use of `macos-latest` which currently is v15. This runner uses XCode 16 by default. This is also [the lowest version available for this runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md).
To be able to test with XCode 15 the PR uses the `macos-14` runner.