### PR TITLE
Update CI to use GCC 13 and Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,51 +9,51 @@ jobs:
       matrix:
         include:
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
-            COMPILER: 'g++-4.7'
-            EXTRA_APT_PACKAGES: 'g++-4.7'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++4.7
+            COMPILER: 'g++-13'
+            EXTRA_APT_PACKAGES: 'g++-13'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++13
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
-            COMPILER: 'g++-4.8'
-            EXTRA_APT_PACKAGES: 'g++-4.8'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++4.8
+            COMPILER: 'g++-13'
+            EXTRA_APT_PACKAGES: 'g++-13'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++13
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
-            COMPILER: 'g++-4.9'
-            EXTRA_APT_PACKAGES: 'g++-4.9'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++4.9
+            COMPILER: 'g++-13'
+            EXTRA_APT_PACKAGES: 'g++-13'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++13
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'g++-5'
-            EXTRA_APT_PACKAGES: 'g++-5'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++4.5
+            COMPILER: 'g++-13'
+            EXTRA_APT_PACKAGES: 'g++-13'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++13
 
-          - COMPILER: 'g++-5'
-            EXTRA_APT_PACKAGES: 'gcc-multilib g++-5-multilib linux-libc-dev'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++5-multilib
+          - COMPILER: 'g++-14'
+            EXTRA_APT_PACKAGES: 'gcc-multilib g++-14-multilib linux-libc-dev'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++14-multilib
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'g++-6'
-            EXTRA_APT_PACKAGES: 'g++-6'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++6
+            COMPILER: 'g++-14'
+            EXTRA_APT_PACKAGES: 'g++-14'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++14
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
-            COMPILER: 'g++-7'
-            EXTRA_APT_PACKAGES: 'g++-7'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++7
+            COMPILER: 'g++-14'
+            EXTRA_APT_PACKAGES: 'g++-14'
+            CONTAINER: ubuntu:24.04
+            NAME: ubuntu-24.04-g++14
 
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
-            COMPILER: 'g++-8'
-            EXTRA_APT_PACKAGES: 'g++-8'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-g++8
+            COMPILER: 'g++-12'
+            EXTRA_APT_PACKAGES: 'g++-12'
+            CONTAINER: ubuntu:22.04
+            NAME: ubuntu-22.04-g++12
           
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
             COMPILER: 'g++-9'
@@ -66,76 +66,6 @@ jobs:
             EXTRA_APT_PACKAGES: 'g++-10'
             CONTAINER: ubuntu:20.04
             NAME: ubuntu-20.04-g++10
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-3.5'
-            EXTRA_APT_PACKAGES: 'clang-3.5'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.5 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-3.5
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-3.6'
-            EXTRA_APT_PACKAGES: 'clang-3.6'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.6 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-3.6
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-3.7'
-            EXTRA_APT_PACKAGES: 'clang-3.7'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.7 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-3.7
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-3.8'
-            EXTRA_APT_PACKAGES: 'clang-3.8'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.8 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-3.8
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-3.9'
-            EXTRA_APT_PACKAGES: 'clang-3.9'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/precise/ llvm-toolchain-precise-3.9 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-3.9
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-4.0'
-            EXTRA_APT_PACKAGES: 'clang-4.0 g++-5'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-4.0
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON'
-            COMPILER: 'clang++-5.0'
-            EXTRA_APT_PACKAGES: 'clang-5.0 g++-7'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-5.0
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
-            COMPILER: 'clang++-5.0'
-            EXTRA_APT_PACKAGES: 'clang-5.0 g++-7'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-5.0-cpp17
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
-            COMPILER: 'clang++-7'
-            EXTRA_APT_PACKAGES: 'clang-7 g++-7'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-7-cpp17
-
-          - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17 -DCLANG_USE_LIBCPP=ON -DSKIP_PERFORMANCE_COMPARISON=ON'
-            COMPILER: 'clang++-8'
-            EXTRA_APT_PACKAGES: 'clang-8 g++-8 libc++-8-dev libc++abi-8-dev'
-            LLVM_APT_SOURCE: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main'
-            CONTAINER: ubuntu:16.04
-            NAME: ubuntu-16.04-clang-8-cpp17
           
           - CMAKE_OPTIONS: '-DSKIP_PORTABILITY_TEST=ON -DCMAKE_CXX_STANDARD=17'
             COMPILER: 'clang++-9'
@@ -164,7 +94,7 @@ jobs:
 
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: install deps and test
       uses: addnab/docker-run-action@v3
       with:
@@ -178,10 +108,6 @@ jobs:
 
           # Add apt repositories for older Ubuntu
           . /etc/os-release
-          if [[ "${VERSION_ID}" == "16.04" ]]; then
-            add-apt-repository ppa:ubuntu-toolchain-r/test -y
-            add-apt-repository ppa:mhier/libboost-latest -y
-          fi
 
           if [[ "${{ matrix.LLVM_APT_SOURCE }}" != "" ]]; then
             wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -192,7 +118,7 @@ jobs:
 
           # Install apt packages
           apt-get install libboost-serialization-dev libboost-dev ${{ matrix.EXTRA_APT_PACKAGES }} -y
-          pip3 install --upgrade "pip < 21.0"
+          pip3 install --upgrade "pip"
           pip3 install cmake
 
           # Set compiler and env variables
@@ -208,11 +134,6 @@ jobs:
           LLVM_INSTALL=${DEPS_DIR}/llvm/install
           # if in linux and compiler clang and llvm not installed
           if [[ "${CXX}" == "clang"* && -n "$(ls -A ${LLVM_INSTALL})" ]]; then
-            if   [[ "${CXX}" == "clang++-3.6" ]]; then LLVM_VERSION="3.6.2";
-            elif [[ "${CXX}" == "clang++-3.7" ]]; then LLVM_VERSION="3.7.1";
-            elif [[ "${CXX}" == "clang++-3.8" ]]; then LLVM_VERSION="3.8.1";
-            elif [[ "${CXX}" == "clang++-3.9" ]]; then LLVM_VERSION="3.9.1";
-            fi
             LLVM_URL="http://llvm.org/releases/${LLVM_VERSION}/llvm-${LLVM_VERSION}.src.tar.xz"
             LIBCXX_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxx-${LLVM_VERSION}.src.tar.xz"
             LIBCXXABI_URL="http://llvm.org/releases/${LLVM_VERSION}/libcxxabi-${LLVM_VERSION}.src.tar.xz"


### PR DESCRIPTION
Updated CI configuration to use newer compiler versions and Ubuntu containers. Removed deprecated compiler configurations.