### PR TITLE
perf(portable_binary): skip byte-swap for DataSize==1

### DIFF
--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -133,7 +133,7 @@ namespace cereal
       {
         std::streamsize writtenSize = 0;
 
-        if( itsConvertEndianness )
+        if( itsConvertEndianness && DataSize > 1 )
         {
           for( std::streamsize i = 0; i < size; i += DataSize )
             for( std::streamsize j = 0; j < DataSize; ++j )
@@ -245,7 +245,7 @@ namespace cereal
           throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(readSize));
 
         // flip bits if needed
-        if( itsConvertEndianness )
+        if( itsConvertEndianness && DataSize > 1 )
         {
           std::uint8_t * ptr = reinterpret_cast<std::uint8_t*>( data );
           for( std::streamsize i = 0; i < size; i += DataSize )


### PR DESCRIPTION
## Problem

When serializing a `std::vector` of a single-byte arithmetic type (e.g. `std::vector<std::uint8_t>`, `std::vector<char>`, `std::vector<unsigned char>`) through `PortableBinaryArchive` with endianness conversion enabled, the data still enters the byte-swapping slow path even though swapping a single byte is a no-op.

In `vector.hpp`, arithmetic vectors use the `binary_data` fast path:

```cpp
ar( binary_data( vector.data(), vector.size() * sizeof(T) ) );
```

This dispatches to `saveBinary<sizeof(T)>` / `loadBinary<sizeof(T)>`. For `sizeof(T) == 1`, `DataSize` is `1`, so:

- `swap_bytes<1>` iterates `0` times — a no-op the compiler can eliminate
- **but** the surrounding control flow still pays the cost:
  - `saveBinary`: O(n) single-byte `sputn(..., 1)` calls instead of one bulk `sputn`
  - `loadBinary`: O(n) empty swap-loop iterations

## Fix

Gate the byte-swap path behind `DataSize > 1` in both functions:

```cpp
// saveBinary (include/cereal/archives/portable_binary.hpp)
if( itsConvertEndianness && DataSize > 1 )   // was: if( itsConvertEndianness )
{ /* per-byte reversed write */ }
else
  writtenSize = itsStream.rdbuf()->sputn( ... , size );   // bulk write

// loadBinary
if( itsConvertEndianness && DataSize > 1 )   // was: if( itsConvertEndianness )
{ /* swap loop */ }
```

## Why this is safe

- **Correctness:** Swapping a single byte is a no-op (`swap_bytes<1>` iterates `0` times), so skipping it produces byte-identical output for `DataSize == 1`.
- **Zero added runtime cost:** `DataSize` is a non-type template parameter, so `DataSize > 1` is a compile-time constant. Compilers eliminate the dead branch, leaving the `DataSize > 1` path identical to before.
- **No behavior change** for multi-byte types (`uint16/32/64`, `float`, `double`, etc.).

## Performance impact

For `std::vector<std::uint8_t>` (or any 1-byte vector) serialized with endianness conversion enabled:

- **Save:** collapses O(n) single-byte `sputn` calls into one bulk `sputn` of the whole buffer.
- **Load:** removes O(n) empty swap-loop iterations.

## Files changed

`include/cereal/archives/portable_binary.hpp` — 2 lines modified (both `if` conditions).
